### PR TITLE
Send model events to google analytics

### DIFF
--- a/src/lab/md2d/controllers/scripting-api.js
+++ b/src/lab/md2d/controllers/scripting-api.js
@@ -47,6 +47,44 @@ define(function (require) {
         return model.getNumberOfAngularBonds();
       },
 
+      /* Send a track page context event to Google Analytics */
+      trackPageContext: function trackPageContext(category, action, label) {
+        var pageContext,
+            googleAnalytics = _gaq;
+
+        if (typeof googleAnalytics === 'undefined'){
+          console.error("Google Analytics not defined, Can not send the Track Page Context event");
+          return;
+        }
+        if (!category) {
+          category = "Interactive";
+        }
+        if (!action) {
+          action = "Page Context";
+        }
+        if (!label) {
+          label = JSON.stringify({ pageContext: document.referrer, interactive: document.location.href });
+        }
+        console.log("Sending a track page context event to Google Analytics");
+        googleAnalytics.push(['_trackEvent', category, action, label]);
+      },
+
+      /* Send a tracking event to Google Analytics */
+      trackEvent: function trackEvent(category, action, label) {
+        var googleAnalytics = _gaq;
+
+        if (typeof googleAnalytics === 'undefined'){
+          console.error("Google Analytics not defined, Can not send trackEvent");
+          return;
+        }
+        if (!category) {
+          category = "Interactive";
+        }
+        console.log("Sending a track page event Google Analytics (category:action:label):");
+        console.log("(" + category + ":"  + action + ":" + label + ")");
+        googleAnalytics.push(['_trackEvent', category, action, label]);
+      },
+
       addAtom: function addAtom(props, options) {
         if (options && options.suppressRepaint) {
           // Translate suppressRepaint option to


### PR DESCRIPTION
This addresses a PT Storyfor tracking interactives and models by Google Analytics.
https://www.pivotaltracker.com/projects/731349#!/stories/46994837.

Goto http://lab3.dev.concord.org/interactives#/interactives/interactives_basic-examples_onClick_with_Tracking

Open the interactive editor and view the plotAction -> "adds an atom" onClick handler.
It's action should be:
"action": [
            "onClick('plot', function(x, y, d, i) {",
            "  trackPageContext();",
            "  trackEvent('', 'Add Atoms', 'Adding Atoms to onClick Demo Interactive');",
            "  addAtom({x: x, y: y});",
            "});"
          ]

Note the trackPageContext and trackEvent scripting API functions. 
The trackPageContext function will send Interactive "Page Context" action/event to Google Analytics with the url of the containing page and the url of the embedded page.

The trackEvent function will send a "Add Atoms" action/event to Google Analytics.

These events can be viewed at https://www.google.com/analytics/web/#realtime/rt-event/a6899787w68675665p70722550/%3Ffilter.list%3D14%3D%3DREFERRAL%3B7%3D%3Dlocalhost%25253A4000%3B/

They are triggered by selecting "adds an atom" radio button and clicking in the model.

To view how this would work in an embedded page go to (this is a page served by development environment, which is not always available): 
http://niftytoad.fwd.wf/gaq_lab3_test.html
