### PR TITLE
layerPosition property is used to render images within a layer

### DIFF
--- a/src/helpers/md2d/mml-parser.coffee
+++ b/src/helpers/md2d/mml-parser.coffee
@@ -390,6 +390,7 @@ parseMML = (mmlString) ->
           imageHostIndex: imageHostIndex,
           imageHostType: imageHostType
           imageLayer: imageLayer
+          imageLayerPosition: imageLayerPosition
           imageX: imageX
           imageY: imageY
         },
@@ -409,10 +410,11 @@ parseMML = (mmlString) ->
         imageHostType = $image.find("[property=hostType] string").text()
         imageHostType = imageHostType.slice(imageHostType.lastIndexOf(".")+1)
         imageLayer = parseInt $image.find("[property=layer] int").text()
+        imageLayerPosition = parseInt $image.find("[property=layerPosition] byte").text()
         imageX = parseFloat $image.find("[property=x] double").text()
         imageY = parseFloat $image.find("[property=y] double").text()
         [imageX, imageY] = toNextgenCoordinates imageX, imageY
-        images.push {imageUri: imageUri, imageHostIndex: imageHostIndex, imageHostType: imageHostType, imageLayer: imageLayer, imageX: imageX, imageY: imageY }
+        images.push {imageUri: imageUri, imageHostIndex: imageHostIndex, imageHostType: imageHostType, imageLayer: imageLayer, imageLayerPosition: imageLayerPosition, imageX: imageX, imageY: imageY }
 
     ###
       Text boxes. TODO: factor out pattern common to MML parsing of images and text boxes

--- a/test/fixtures/mml-conversions/expected-json/image-layers.json
+++ b/test/fixtures/mml-conversions/expected-json/image-layers.json
@@ -73,6 +73,7 @@
         "imageHostIndex": 0,
         "imageHostType": "",
         "imageLayer": 1,
+        "imageLayerPosition": 1,
         "imageX": 1.73,
         "imageY": 2.76
       },
@@ -81,6 +82,7 @@
         "imageHostIndex": 0,
         "imageHostType": "",
         "imageLayer": 2,
+        "imageLayerPosition": 2,
         "imageX": 0.18,
         "imageY": 1.28
       },
@@ -89,6 +91,7 @@
         "imageHostIndex": 0,
         "imageHostType": "",
         "imageLayer": 2,
+        "imageLayerPosition": 3,
         "imageX": 1.88,
         "imageY": 1.42
       }


### PR DESCRIPTION
This fixes sporadic render order issues with image-layers and Diffusion Across a Permeable membrane by using layerPosition property from the classic MW models. The renderer uses this to order the svg image nodes accordingly such that the specified layer position order is respected by the rendering engine. The image-layers.mml -> image-layers.json conversion output test has the updated json output for the test to pass.

Without using the layerPosition property within a layer it is possible for element z-order to change depending on how long it takes for the elements to be retrieved / rendered. To see this, open the Image Layers test and change size a few times. Every now and then the below top element will appear below bottom. With this patch, the order is consistent.

Smoke tested the public curriculum models and so no bugs were introduced by this change to the rendering engine.
