### PR TITLE
Track GA pageviews after the interactive is loaded with ajax

### DIFF
--- a/script/setup.rb
+++ b/script/setup.rb
@@ -29,16 +29,9 @@ end
 if CONFIG[:google_analytics] && CONFIG[:google_analytics][:account_id]
   ANALYTICS = <<-HEREDOC
   <script type="text/javascript">
-    // make an array out of the URL's hashtag string, splitting the string at every ampersand
-    var my_hashtag_array = location.hash.split('&');
-
-    // grab the first value of the array (assuming that's the value that indicates which interactive is being viewed)
-    var my_hashtag = my_hashtag_array[0];
-
     var _gaq = _gaq || [];
     _gaq.push(['_setAccount', '#{CONFIG[:google_analytics][:account_id]}']);
     _gaq.push(['_setAllowAnchor', true]);
-    _gaq.push(['_trackPageview', location.pathname + my_hashtag]);
     (function() {
     var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
     ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';

--- a/src/examples/interactives/application.js
+++ b/src/examples/interactives/application.js
@@ -91,6 +91,19 @@ AUTHORING = false;
       modelRemoteKeys = ['id', 'from_import', 'location'],
       modelButtonHandlersAdded = false;
 
+  function sendGAPageview(){
+    // send the pageview to GA
+    if (typeof _gaq === 'undefined'){
+      return;
+    }
+    // make an array out of the URL's hashtag string, splitting the string at every ampersand
+    var my_hashtag_array = location.hash.split('&');
+
+    // grab the first value of the array (assuming that's the value that indicates which interactive is being viewed)
+    var my_hashtag = my_hashtag_array[0];
+    _gaq.push(['_trackPageview', location.pathname + my_hashtag]);
+  }
+
   function isEmbeddablePage() {
     return ($selectInteractive.length === 0);
   }
@@ -168,6 +181,7 @@ AUTHORING = false;
       if (interactive.title) {
         document.title = interactive.title;
       }
+      sendGAPageview();
 
       interactiveDefinitionLoaded.resolve();
     })


### PR DESCRIPTION
This is a fix for how the page title gets reported to GA. See PT bug https://www.pivotaltracker.com/s/projects/731349/stories/47976947

From this PT bug:
Currently two page titles are reported to GA for each interactive viewed. This is because the html page for interactives sets the title on page load then this title is changed to the title of a specific interactive after it is loaded by ajax.

Currently, the GA reports for interactives filter out the titles set by the html files. For embedded interactives this title is "Simple Atoms Interactive Model" set in server/public/examples/interactives/embeddable.html. Non embedded interactives title is "Interactive Browser" set in server/public/examples/interactives/interactives.html

The fix is to move the code that reports to GA to the handler/callback thats invoked after the interactive is loaded via ajax.
