### PR TITLE
expose existing image properties to scripting api

### DIFF
--- a/src/interactives/basic-examples/image-properties.json
+++ b/src/interactives/basic-examples/image-properties.json
@@ -1,0 +1,41 @@
+{
+  "title": "Image Property Manipulation",
+  "publicationStatus": "public",
+  "subtitle": "Demonstration of how to get and set image properties",
+  "about": [],
+  "models": [
+    {
+      "type": "md2d",
+      "id": "forceDirectionVDG$0",
+      "url": "imports/legacy-mw-content/converted/interactions/force-direction-VDG-negative/forceDirectionVDG$0.json",
+      "importedFrom": "imports/legacy-mw-content/interactions/force-direction-VDG-negative/forceDirectionVDG$0.mml",
+      "viewOptions": {
+        "controlButtons": "reset",
+        "imageMapping": {
+          "vdg.png": "vdg.svg"
+        }
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "vdg-visible",
+      "initialValue": true,
+      "onChange": [
+        "if (value) {",
+        "  setImageProperties(0,{imageX: 1.29, imageY: 1.36});",
+        "} else {",
+        "  setImageProperties(0,{imageX: 1, imageY: -10});",
+        "}"
+      ]
+    }
+  ],
+  "components": [
+    {
+      "type": "checkbox",
+      "id": "toggle-visibility",
+      "text": "VDG Visible?",
+      "property": "vdg-visible"
+    }
+  ]
+}

--- a/src/lab/md2d/controllers/scripting-api.js
+++ b/src/lab/md2d/controllers/scripting-api.js
@@ -763,6 +763,14 @@ define(function (require) {
         return model.getNumberOfLines();
       },
 
+      getImageProperties: function(i) {
+        return model.getImageProperties(i);
+      },
+
+      setImageProperties: function(i, props) {
+        setProperty(model.setImageProperties, i, props);
+      },
+
       repaintIfReady: function(options) {
         if (!(batchDepth > 0 || options && options.suppressRepaint)) {
           api.repaint();

--- a/src/lab/md2d/models/metadata.js
+++ b/src/lab/md2d/models/metadata.js
@@ -762,6 +762,32 @@ define(function() {
       }
     },
 
+    image: {
+      imageUri: {
+        required: true
+      },
+      imageX: {
+        defaultValue: 0,
+        required: true
+      },
+      imageY: {
+        defaultValue: 0,
+        required: true
+      },
+      imageHostType: {
+        defaultValue: ""
+      },
+      imageHostIndex: {
+        defaultValue: 0
+      },
+      imageLayer: {
+        defaultValue: 1
+      },
+      imageLayerPosition: {
+        defaultValue: 1
+      }
+    },
+
     quantumDynamics: {
       elementEnergyLevels: {
         defaultValue: []

--- a/src/lab/md2d/models/modeler.js
+++ b/src/lab/md2d/models/modeler.js
@@ -172,7 +172,7 @@ define(function(require) {
           d.addEventTypes("tick",
                           "addAtom", "removeAtom", "addRadialBond", "removeRadialBond",
                           "addElectricField", "removeElectricField", "changeElectricField",
-                          "removeAngularBond", "textBoxesChanged");
+                          "removeAngularBond", "textBoxesChanged", "imagesChanged");
           return d;
         }()),
 
@@ -1531,8 +1531,29 @@ define(function(require) {
       }
     };
 
+    model.setImageProperties = function(i, props) {
+      var image = model.get('images')[i],
+          prop;
+
+      if (image) {
+        props = validator.validate(metadata.image, props);
+        for (prop in props) {
+          if (props.hasOwnProperty(prop)) {
+            image[prop] = props[prop];
+          }
+        }
+        dispatch.imagesChanged();
+      } else {
+        throw new Error("Image \"" + i + "\" does not exist, so it cannot have properties set.");
+      }
+    };
+
     model.getTextBoxProperties = function(i) {
       return model.get('textBoxes')[i];
+    };
+
+    model.getImageProperties = function(i) {
+      return model.get('images')[i];
     };
 
     /**

--- a/src/lab/md2d/views/renderer.js
+++ b/src/lab/md2d/views/renderer.js
@@ -2190,6 +2190,7 @@ define(function(require) {
       model.on('addRadialBond', redrawClickableObjects(setupRadialBonds));
       model.on('removeRadialBond', redrawClickableObjects(setupRadialBonds));
       model.on('textBoxesChanged', redrawClickableObjects(drawTextBoxes));
+      model.on('imagesChanged', redrawClickableObjects(drawImageAttachment));
       model.on('addElectricField', setupElectricField);
       model.on('removeElectricField', setupElectricField);
       model.on('changeElectricField', setupElectricField);


### PR DESCRIPTION
Expose the existing image properties to the interactive scripting api.

[#57828832]

This only exposes the existing image properties in the md2d engine. It does not add new properties that may be of interest (e.g. visibility). Because image properties are treated differently that other scriptable elements (shapes, textboxes), adding and controlling other properties would require more extensive changes to the md2d engine and renderer.
