### PR TITLE
Use fixed ‘labels’ property in dgExporterT

### DIFF
--- a/src/lab/import-export/dg-exporter.js
+++ b/src/lab/import-export/dg-exporter.js
@@ -152,6 +152,8 @@ define(function(require) {
           perRunColumnValues = [],
           timeSeriesColumnLabels = [],
           shouldExportTimeSeries,
+          parentTableName,
+          childTableName,
           i;
 
       // Extract metadata in the forms needed for export, ie values need to be an array of values,
@@ -188,39 +190,39 @@ define(function(require) {
 
       // Export.
 
-      // Step 1. Tell DG we're a "game".
-      this.doCommand('initGame', {
-        name: this.gameName
-      });
+      if (shouldExportTimeSeries) {
+        parentTableName = this.parentTableLabels.pluralCase;
+        childTableName = this.childTableLabels.pluralCase;
+      } else {
+        parentTableName = this.singleTableLabels.pluralCase;
+      }
 
-      // Step 2. Create a parent table. Each row will have the value of each of the perRunData,
-      // plus the number of time series points that are being exported for combination of
-      // parameter values.
-      // (It seems to be ok to call this multiple times with the same collection name, e.g., for
-      // multiple exports during a single DG session.)
-      this.doCommand('createCollection', {
-        name: 'parent',
+      var collections = [{
+        name: parentTableName,
         attrs: perRunColumnLabels,
         childAttrName: 'runs',
         labels: shouldExportTimeSeries ? this.parentTableLabels : this.singleTableLabels,
         collapseChildren: true
-      });
+      }];
 
-      // Step 3. Create a table to be the child of the parent table; each row of the child
-      // has a single time series reading (time, property1, property2...)
-      // (Again, it seems to be ok to call this for the same table multiple times per DG session)
       if (shouldExportTimeSeries) {
-        this.doCommand('createCollection', {
-          name: 'child',
+        collections.push({
+          name: childTableName,
           attrs: timeSeriesColumnLabels,
-          labels: this.singleTableLabels
+          labels: this.childTableLabels
         });
       }
+
+      // Step 1. Tell DG we're a "game".
+      this.doCommand('initGame', {
+        name: this.gameName,
+        collections: collections
+      });
 
       // Step 4. Open a row in the parent table. This will contain the individual time series
       // readings as children.
       this.doCommand('openCase', {
-        collection: 'parent',
+        collection: parentTableName,
         values: perRunColumnValues
       }, function(parentCase) {
 
@@ -228,7 +230,7 @@ define(function(require) {
         // do this inline, so we don't need to call openCase, closeCase for each row.
         if (shouldExportTimeSeries) {
           this.doCommand('createCases', {
-            collection: 'child',
+            collection: childTableName,
             values: timeSeriesData,
             parent: parentCase.caseID
           });
@@ -236,7 +238,7 @@ define(function(require) {
 
         // Step 6. Close the case.
         this.doCommand('closeCase', {
-          collection: 'parent',
+          collection: parentTableName,
           caseID: parentCase.caseID
         });
       }.bind(this));


### PR DESCRIPTION
This should improve the labels of tables and collapsed rows after exporting data from Lab to CODAP.

It cannot be released until CODAP is updated with a bugfix for the `labels` property of collections.
