### PR TITLE
Fix dataset remove datapoint and grapher

### DIFF
--- a/src/lab/common/controllers/data-set.js
+++ b/src/lab/common/controllers/data-set.js
@@ -180,6 +180,50 @@ define(function () {
     return maxLength;
   };
 
+  DataSet.prototype.minLength = function(props) {
+    var minLength = Infinity;
+    var context = this;
+    props.forEach(function (prop) {
+      if (minLength > context._data[prop].length) minLength = context._data[prop].length;
+    });
+    return minLength;
+  };
+
+  /**
+   Returns index of a data point if all provided values are matching.
+   For example if data set has following properties and values:
+   {
+     x: [0, 1, 2, 3],
+     y: [0, 10, 20, 30]
+   }
+   then:
+   dataset.dataPointIndex({x: 2, y: 20}); // returns: 2
+   dataset.dataPointIndex({x: 2});        // returns: 2
+   dataset.dataPointIndex({x: 2, y: 99}); // returns: -1 (not found)
+   */
+  DataSet.prototype.dataPointIndex = function (values) {
+    var props = Object.keys(values);
+    var valuesLength = this.minLength(props);
+    var propsLength = props.length;
+    var allValuesMatching;
+    var prop;
+
+    for (var index = 0; index < valuesLength; index++) {
+      allValuesMatching = true;
+      for (var j = 0; j < propsLength; j++) {
+        prop = props[j];
+        if (this._data[prop][index] !== values[prop]) {
+          allValuesMatching = false;
+          break;
+        }
+      }
+      if (allValuesMatching) {
+        return index;
+      }
+    }
+    return -1;
+  };
+
   /**
     Resets data sat to its initial data. When initial data is not provided, clears data
     set (in such case this function behaves exactly like .clearData()).
@@ -224,23 +268,15 @@ define(function () {
     this._trigger(DataSet.Events.SAMPLE_ADDED, dataPoint);
   };
 
-  DataSet.prototype.removeDataPoint = function (props, values) {
-    if (!props) {
-      props = this._modelProperties;
-    }
-    var dataPoint = {},
-        context = this,
-        idx = -1;
-    // TODO Don't use the first prop, assuming it's the x property
-    props.slice(0,1).forEach(function (prop) {
-      var val = values && values[prop] !== undefined ? values[prop] : context._getModelProperty(prop);
-      if (val === undefined) return;
-      idx = context._data[prop].indexOf(val);
-      // Set the value to null
-      context._data[prop][idx] = null;
-    });
+  DataSet.prototype.removeDataPoint = function (values) {
+    var context = this;
+    var props = Object.keys(values);
+    var idx = this.dataPointIndex(values);
 
-    if (idx != -1) {
+    if (idx !== -1) {
+      props.forEach(function (prop) {
+        context._data[prop][idx] = null;
+      });
       this._trigger(DataSet.Events.SAMPLE_REMOVED, {props: props, values: values, index: idx});
     }
   };
@@ -356,7 +392,7 @@ define(function () {
         this.editDataPoint(data['index'], data['property'], data['newValue']);
         break;
       case DataSet.Events.SAMPLE_REMOVED:
-        this.removeDataPoint(data['props'], data['values']);
+        this.removeDataPoint(data['values']);
         break;
 
       case DataSet.Events.DATA_TRUNCATED:

--- a/src/lab/common/controllers/data-set.js
+++ b/src/lab/common/controllers/data-set.js
@@ -268,17 +268,12 @@ define(function () {
     this._trigger(DataSet.Events.SAMPLE_ADDED, dataPoint);
   };
 
-  DataSet.prototype.removeDataPoint = function (values) {
+  DataSet.prototype.removeDataPoint = function (props, index) {
     var context = this;
-    var props = Object.keys(values);
-    var idx = this.dataPointIndex(values);
-
-    if (idx !== -1) {
-      props.forEach(function (prop) {
-        context._data[prop][idx] = null;
-      });
-      this._trigger(DataSet.Events.SAMPLE_REMOVED, {props: props, values: values, index: idx});
-    }
+    props.forEach(function (prop) {
+      context._data[prop][index] = null;
+    });
+    this._trigger(DataSet.Events.SAMPLE_REMOVED, {props: props, index: index});
   };
 
 
@@ -392,7 +387,7 @@ define(function () {
         this.editDataPoint(data['index'], data['property'], data['newValue']);
         break;
       case DataSet.Events.SAMPLE_REMOVED:
-        this.removeDataPoint(data['values']);
+        this.removeDataPoint(data['props'], data['index']);
         break;
 
       case DataSet.Events.DATA_TRUNCATED:

--- a/src/lab/common/controllers/graph-controller.js
+++ b/src/lab/common/controllers/graph-controller.js
@@ -325,7 +325,7 @@ define(function (require) {
       var index = evt.data.index,
           props = evt.data.props;
       properties.forEach(function (prop, propIdx) {
-        if (props.indexOf(prop) != -1) {
+        if (props.indexOf(prop) !== -1) {
           grapher.deletePoint(index, propIdx);
         }
       });
@@ -343,15 +343,17 @@ define(function (require) {
 
     function graphChangedDataPoint(evt) {
       ignoreDataSetEvents = true;
-      var yPro = component.drawProperty || properties[0];
-          xPro = xProp(yPro),
+      var yPro = component.drawProperty || properties[0],
+          xPro = xProp(properties.indexOf(yPro)),
           data = {};
       data[xPro] = evt.point[0];
       data[yPro] = evt.point[1];
-      if (evt.action == "added") {
+      if (evt.action === "added") {
         dataSet.appendDataPoint([xPro, yPro], data);
-      } else if (evt.action == "removed") {
-        dataSet.removeDataPoint([xPro, yPro], data);
+      } else if (evt.action === "removed") {
+        // Make sure that data has both X and Y values, so the point can be identified.
+        // X values don't have to be unique - grapher sometimes adds the same point twice...
+        dataSet.removeDataPoint(data);
       }
       ignoreDataSetEvents = false;
     }

--- a/src/lab/common/controllers/graph-controller.js
+++ b/src/lab/common/controllers/graph-controller.js
@@ -351,9 +351,11 @@ define(function (require) {
       if (evt.action === "added") {
         dataSet.appendDataPoint([xPro, yPro], data);
       } else if (evt.action === "removed") {
-        // Make sure that data has both X and Y values, so the point can be identified.
+        // Make sure that data has both X and Y values, so the point can be clearly identified.
         // X values don't have to be unique - grapher sometimes adds the same point twice...
-        dataSet.removeDataPoint(data);
+        var idx = dataSet.dataPointIndex(data);
+        // Remove only Y property value, X property can be shared.
+        dataSet.removeDataPoint([yPro], idx);
       }
       ignoreDataSetEvents = false;
     }


### PR DESCRIPTION
Changes summary:

- `lab-grapher` submodule is updated, there was a bug causing errors once dataset with null values was loaded.
- `DataSet#removeDataPoint` interface is more sane now - just set of properties to remove and index.
- When user is drawing points on the graph, only Y values are removed from dataset (@scytacki, @psndcsrv, X value is untouched, so authors can share X property). Previously there was a bug and only X value was removed.
- `GraphController` is making sure that correct point is removed when user is drawing on the graph (it looks for the exact combination of X and Y values, previously it wasn't ensured at all).

Tests:

1. You can checkout this branch, run local Lab server, open:
   http://lab.concord.org/interactives-local.html#interactives/itsi/sensor/prediction-prediction.json
   and then:
  - Draw some points. 
  - Draw some points again, make sure that you modify previously added points.
  - Open interactive editor, update JSON from interactive.
  - Update interactive from JSON.
  - Try to draw something again.

  It should just work. If you try to do it using the production version of Lab, the last step will fail.

2. You can modify this example to use local Lab:
   http://concord-consortium.github.io/lab-examples/pages/10-sensor-prediction.html
   and it still works, so we won't break ITSI.

3. Finally Lab interactives can work fine with LARA global interactive state feature (it's not on production yet, so I'm not providing any test steps).

