### PR TITLE
allow authors to put div content in a separate file

### DIFF
--- a/src/lab/common/controllers/div-controller.js
+++ b/src/lab/common/controllers/div-controller.js
@@ -3,7 +3,8 @@
 define(function (require) {
 
   var inherit              = require('common/inherit'),
-      InteractiveComponent = require('common/controllers/interactive-component');
+      InteractiveComponent = require('common/controllers/interactive-component'),
+      alert                = require('common/alert');
 
   /**
    * Simplest component controller which just inherits from InteractiveComponent, simply
@@ -18,9 +19,17 @@ define(function (require) {
     InteractiveComponent.call(this, "div", component, scriptingAPI, controller);
     var content = component.content;
     var divController = this;
-    if (component.src) {
+    if (component.url) {
+      // make sure the user sets the width and height because otherwise the layout
+      // will be broken
+      if( component.width === "auto" || component.height === "auto") {
+        alert("This interactive has a remote div component.\n"+
+              "The width and/or height is not set.\n"+
+              "Please set both the width and height.");
+      }
 
-      $.ajax(component.src, {
+
+      $.ajax(component.url, {
         dataType: "html",
         complete: function (data){
           divController.$element.append(data.responseText);

--- a/src/lab/common/controllers/div-controller.js
+++ b/src/lab/common/controllers/div-controller.js
@@ -17,10 +17,21 @@ define(function (require) {
     // Call super constructor.
     InteractiveComponent.call(this, "div", component, scriptingAPI, controller);
     var content = component.content;
-    if (content && content.join) {
-      content = content.join("\n");
+    var divController = this;
+    if (component.src) {
+
+      $.ajax(component.src, {
+        dataType: "html",
+        complete: function (data){
+          divController.$element.append(data.responseText);
+        }
+      });
+    } else {
+      if (content && content.join) {
+        content = content.join("\n");
+      }
+      this.$element.append(content);
     }
-    this.$element.append(content);
   }
   inherit(DivController, InteractiveComponent);
 

--- a/src/lab/common/controllers/interactive-metadata.js
+++ b/src/lab/common/controllers/interactive-metadata.js
@@ -464,9 +464,9 @@ define(function() {
         required: true
       },
       content: {
-        conflictsWith: ["src"]
+        conflictsWith: ["url"]
       },
-      src: {
+      url: {
         conflictsWith: ["content"]
       },
       width: {

--- a/src/lab/common/controllers/interactive-metadata.js
+++ b/src/lab/common/controllers/interactive-metadata.js
@@ -466,6 +466,9 @@ define(function() {
       content: {
         defaultValue: ""
       },
+      src: {
+        defaultValue: ""
+      },
       width: {
         defaultValue: "auto"
       },

--- a/src/lab/common/controllers/interactive-metadata.js
+++ b/src/lab/common/controllers/interactive-metadata.js
@@ -464,10 +464,10 @@ define(function() {
         required: true
       },
       content: {
-        defaultValue: ""
+        conflictsWith: ["src"]
       },
       src: {
-        defaultValue: ""
+        conflictsWith: ["content"]
       },
       width: {
         defaultValue: "auto"


### PR DESCRIPTION
You can see an example of this here:
http://lab.concord.org/branch/remote-div/interactives.html#interactives/basic-examples/remote-div-content.json
Here are the files making up that example:
https://github.com/concord-consortium/lab-interactives-site/commit/a25289b5cccd541afc5a6907b0dae8c54816225c

Besides checking the code, I'm curious what other people think about this approach. It allows us to add pretty much any html/javascript to the interactive.  So it will be easier to do more things. Some downsides and mitigations:
- if we had a authoring system that was vulnerable to cross site scripting, this would let users inject remote 'un-sandboxed' scripts. Mitigation: the authoring system could forbid using this.
- it is easy for authors to make interactives that break. Mitigation: use with caution, and make sure to do cross browser testing.
- the layout system can't handle the async part of this. Mitigation: #1 use explicit sizing of the div, so the content doesn't take too much space. #2 add a build step that inlines the div.src as div.content. #3 after the content is loaded the layout system is re-run.
- by using this, I'm not making some paging component that authors can use to flip through scaffolding interactive. Mitigation: none. But in my opinion this approach allows us to make many new kinds of interactives, and if we find we are doing the same things multiple times we could then make Lab components for those things. 

I haven't tested it yet, but I'm pretty sure the scripts in this html content can call the interactives script api methods. So they will have at least as much control as with the iframe-api, and probably they will have more control.

cc @pjanik @psndcsrv @knowuh