### PR TITLE
 Add toggle style to radio buttons

### DIFF
--- a/src/lab/common/controllers/interactive-metadata.js
+++ b/src/lab/common/controllers/interactive-metadata.js
@@ -699,6 +699,10 @@ define(function() {
       type: {
         required: true
       },
+      style: {
+        // "radio" (classic radio button) or "toggle" (looks like group of regular buttons).
+        defaultValue: "radio"
+      },
       orientation: {
         defaultValue: "vertical"
       },

--- a/src/lab/common/controllers/radio-controller.js
+++ b/src/lab/common/controllers/radio-controller.js
@@ -128,8 +128,6 @@ define(function () {
           $('<div class="fakeCheckable">').appendTo($span);
         }
 
-        // $span.append(option.text);
-
         $('<label>')
           .attr("for", component.id + '-' + i)
           .text(option.text)

--- a/src/lab/common/controllers/radio-controller.js
+++ b/src/lab/common/controllers/radio-controller.js
@@ -77,7 +77,7 @@ define(function () {
     }
 
     function initialize() {
-      var $input, $span, $label,
+      var $input, $span, $label, $optionsContainer,
           option, i, len;
 
       model = interactivesController.getModel();
@@ -108,6 +108,8 @@ define(function () {
         $div.append($label);
       }
 
+      $optionsContainer = $("<span>").addClass("options").appendTo($div);
+
       // Create options (<input type="radio">)
       for (i = 0, len = options.length; i < len; i++) {
         option = options[i];
@@ -122,7 +124,7 @@ define(function () {
           .addClass('option')
           .append($input);
         $options.push($span);
-        $div.append($span);
+        $optionsContainer.append($span);
 
         if (component.style === 'radio') {
           $('<div class="fakeCheckable">').appendTo($span);

--- a/src/lab/common/controllers/radio-controller.js
+++ b/src/lab/common/controllers/radio-controller.js
@@ -102,7 +102,7 @@ define(function () {
       $div.addClass(component.style);
 
       if (component.label) {
-        $label = $("<span>").text(component.label);
+        $label = $("<span>").html(component.label);
         $label.addClass("label");
         $label.addClass(component.labelOn === "top" ? "on-top" : "on-left");
         $div.append($label);
@@ -130,7 +130,7 @@ define(function () {
 
         $('<label>')
           .attr("for", component.id + '-' + i)
-          .text(option.text)
+          .html(option.text)
           .appendTo($span);
 
         if (option.disabled) {

--- a/src/sass/lab/_interactive-components.sass
+++ b/src/sass/lab/_interactive-components.sass
@@ -96,6 +96,12 @@
 
 .interactive-radio
   font-size: 1em
+  .option
+    display: inline-block
+    &:hover:not(.lab-disabled)
+      cursor: pointer
+      label
+        cursor: pointer
   &.horizontal
     // Horizontal alignment of options.
     .option + .option
@@ -105,6 +111,32 @@
     // Vertical alignment of options.
     .option
       display: block
+  &.toggle
+    .option
+      @include lab-button
+      line-height: 2em
+      border-radius: 0
+      &.checked
+        @include linear-gradient(#e6e6e6, #fff, $fallback: #fff)
+  &.horizontal.toggle
+    .option + .option
+      margin-left: 0
+      border-left: none
+    .option:first-child
+      border-top-left-radius: 0.7em
+      border-bottom-left-radius: 0.7em
+    .option:last-child
+      border-top-right-radius: 0.7em
+      border-bottom-right-radius: 0.7em
+  &.vertical.toggle
+    .option + .option
+      border-top: none
+    .option:first-child
+      border-top-left-radius: 0.7em
+      border-top-right-radius: 0.7em
+    .option:last-child
+      border-bottom-left-radius: 0.7em
+      border-bottom-right-radius: 0.7em
   .label
     // Main label, for whole radio buttons group.
     vertical-align: middle
@@ -126,8 +158,9 @@
     width: 1.1em
     height: 1.1em
     @include icon-bg("#{$directory}resources/upstatement/unchecked.svg", center, 100%)
-    &.checked
-      @include icon-bg("#{$directory}resources/upstatement/checked.svg", center, 100%)
+  .checked .fakeCheckable
+    @include icon-bg("#{$directory}resources/upstatement/checked.svg", center, 100%)
+
 
 .interactive-pulldown
   font-size: 1em

--- a/src/sass/lab/_interactive-components.sass
+++ b/src/sass/lab/_interactive-components.sass
@@ -118,7 +118,7 @@
       border-radius: 0
       &.checked
         @include linear-gradient(#e6e6e6, #fff, $fallback: #fff)
-  &.horizontal.toggle
+  &.horizontal.toggle .options
     .option + .option
       margin-left: 0
       border-left: none
@@ -128,7 +128,7 @@
     .option:last-child
       border-top-right-radius: 0.7em
       border-bottom-right-radius: 0.7em
-  &.vertical.toggle
+  &.vertical.toggle .options
     .option + .option
       border-top: none
     .option:first-child


### PR DESCRIPTION
This PR adds a new `style` option (`radio` or `toggle`) to the radio button component.
Its DOM structure has been slightly refactored, so now it's enough to add `toggle` class to the top level container and everything else is handled using CSS.