### PR TITLE
Support borders of layout containers

### DIFF
--- a/src/lab/common/layout/semantic-layout.js
+++ b/src/lab/common/layout/semantic-layout.js
@@ -144,8 +144,13 @@ define(function (require) {
 
         for (prop in container) {
           if (!container.hasOwnProperty(prop)) continue;
-          if (/^padding/.test(prop)) {
-            $containerByID[id].css(prop, container[prop]);
+          if (/^margin/.test(prop)) {
+            // Margin is in fact padding of the outer container.
+            $containerByID[id].css(prop.replace("margin", "padding"), container[prop]);
+          }
+          else if (/^padding/.test(prop)) {
+            // Padding is simply padding of the inner container.
+            $innerContainerByID[id].css(prop, container[prop]);
           }
           else if (prop === "align") {
             $containerByID[id].css("text-align", container[prop]);
@@ -158,13 +163,6 @@ define(function (require) {
           }
           else if (prop === "border") {
             $innerContainerByID[id].css("border", container[prop]);
-          }
-          else if (/^inner-padding/.test(prop)) {
-            // Note that this is special kind of padding which is applied to the inner container.
-            // It's useful when you use borders. Probably we should have called the original
-            // "padding" property "margin" instead, but this change is not worth breaking the backwards
-            // compatibility.
-            $innerContainerByID[id].css(prop.substr(6), container[prop]); // remove 'inner-' substring
           }
         }
       }

--- a/src/lab/common/layout/semantic-layout.js
+++ b/src/lab/common/layout/semantic-layout.js
@@ -39,8 +39,10 @@ define(function (require) {
 
         // Container specifications by ID.
         containerSpecByID,
-        // Container jQuery objects by ID.
+        // Container jQuery objects by ID. Main container is used to position widgets.
         $containerByID,
+        // Inner container is used to set margin and padding.
+        $innerContainerByID,
         // Model container jQuery object.
         $modelContainer,
 
@@ -117,6 +119,7 @@ define(function (require) {
       var container, id, prop, i, ii;
 
       $containerByID = {};
+      $innerContainerByID = {};
       containerSpecByID = {};
 
       for (i = 0, ii = containerSpecList.length; i < ii; i++) {
@@ -128,6 +131,8 @@ define(function (require) {
           "display": "inline-block",
           "position": "absolute"
         });
+        $innerContainerByID[id] = $('<div class="inner-container">');
+        $innerContainerByID[id].appendTo($containerByID[id]);
 
         if (container.width === undefined) {
           // Disable wrapping of elements in a container, which
@@ -136,13 +141,12 @@ define(function (require) {
           $containerByID[id].css("white-space", "nowrap");
         }
 
+
         for (prop in container) {
           if (!container.hasOwnProperty(prop)) continue;
-          // Add any padding-* properties directly to the container's style.
-          if (/^padding-/.test(prop)) {
+          if (/^padding/.test(prop)) {
             $containerByID[id].css(prop, container[prop]);
           }
-          // Support also "align" property.
           else if (prop === "align") {
             $containerByID[id].css("text-align", container[prop]);
           }
@@ -151,6 +155,16 @@ define(function (require) {
           }
           else if (prop === "fontScale") {
             $containerByID[id].css("font-size", container[prop] + "em");
+          }
+          else if (prop === "border") {
+            $innerContainerByID[id].css("border", container[prop]);
+          }
+          else if (/^inner-padding/.test(prop)) {
+            // Note that this is special kind of padding which is applied to the inner container.
+            // It's useful when you use borders. Probably we should have called the original
+            // "padding" property "margin" instead, but this change is not worth breaking the backwards
+            // compatibility.
+            $innerContainerByID[id].css(prop.substr(6), container[prop]); // remove 'inner-' substring
           }
         }
       }
@@ -198,7 +212,7 @@ define(function (require) {
           if (jj === 1) {
             $row.css("height", "100%");
           }
-          $containerByID[containerID].append($row);
+          $innerContainerByID[containerID].append($row);
           for (k = 0, kk = items.length; k < kk; k++) {
             id = items[k];
             if (comps[id] === undefined) {
@@ -215,11 +229,11 @@ define(function (require) {
       // Add any remaining components to "bottom" or last container.
       lastContainer = containerSpecByID.bottom || containerSpecList[containerSpecList.length-1];
       if (lastContainer) {
-        $rows = $containerByID[lastContainer.id].children();
+        $rows = $innerContainerByID[lastContainer.id].children();
         $row = $rows.last();
         if (!$row.length) {
           $row = $('<div class="interactive-row"/>');
-          $containerByID[lastContainer.id].append($row);
+          $innerContainerByID[lastContainer.id].append($row);
         }
         for (id in comps) {
           if (!comps.hasOwnProperty(id)) continue;
@@ -232,7 +246,7 @@ define(function (require) {
       // See src/sass/lab/_semantic-layout.sass for .component-spacing class definition.
       for (i = 0, ii = containerSpecList.length; i < ii; i++) {
         // First children() call returns rows, second one components.
-        $containerComponents = $containerByID[containerSpecList[i].id].children().children();
+        $containerComponents = $innerContainerByID[containerSpecList[i].id].children().children();
         if ($containerComponents.length > 1) {
           $containerComponents.addClass("component-spacing");
         }

--- a/src/sass/lab/_semantic-layout.sass
+++ b/src/sass/lab/_semantic-layout.sass
@@ -23,6 +23,10 @@
   height: 100%
   position: relative
 
+.inner-container
+  width: 100%
+  height: 100%
+
 .component-spacing
   margin: 0.3em 0.5em
 


### PR DESCRIPTION
This PR adds two new properties to container definition:
* `border` - accepts typical CSS syntax (e.g. `1px solid gray`).
* `margin` - it's similar to existing `padding` option. Basically unless you add borders, it doesn't matter whether you use `margin` or `padding`. One thing which is a bit different than in regular HTML is that `width` and `height` of a container includes both margin and padding. It's just simpler and ensures that changes are backwards compatible.

Test interactive:
http://lab.concord.org/interactives-dev.html#interactives/layout-tests/borders-test.json
It won't work unless this PR is merged, but you can see new options in JSON, for example:
```
    {
      "id": "bottom-left",
      "left": "model.left",
      "top": "model.bottom",
      "align": "center",
      "border": "1px solid gray",
      "padding": "0.3em",
      "margin-top": "1em",
      "margin-bottom": "1em"
    },
```