### PR TITLE
Quantum Dynamics: support 'monochromatic' property of a light source

### DIFF
--- a/src/lab/mml-converter/mml-converter.coffee
+++ b/src/lab/mml-converter/mml-converter.coffee
@@ -1394,6 +1394,7 @@ define (require) ->
           lightSource = {}
           lightSource.on               = getBooleanProperty( $lightSource, "on"  ) || false
           lightSource.frequency        = getFloatProperty    $lightSource, "frequency"
+          lightSource.monochromatic    = getBooleanProperty  $lightSource, "monochromatic"
           lightSource.radiationPeriod  = getIntProperty      $lightSource, "radiationPeriod"
           lightSource.numberOfBeams    = getIntProperty      $lightSource, "numberOfBeams"
           lightSource.angleOfIncidence = getFloatProperty    $lightSource, "angleOfIncidence"

--- a/src/lab/models/md2d/models/metadata.js
+++ b/src/lab/models/md2d/models/metadata.js
@@ -143,7 +143,7 @@ define(function() {
             return value;
           }
           throw new Error("Invalid 'useDuration' value: " + value);
-        },
+        }
       },
       requestedDuration: {
         defaultValue: null,
@@ -877,6 +877,14 @@ define(function() {
         defaultValue: 1
       },
       lightSource: {
+        defaultValue: {
+          on: false,
+          monochromatic: true,
+          frequency: 1,
+          radiationPeriod: 1000,
+          numberOfBeams: 10,
+          angleOfIncidence: 0
+        }
       }
     },
 

--- a/test/fixtures/mml-conversions/expected-json/quantum-collision.json
+++ b/test/fixtures/mml-conversions/expected-json/quantum-collision.json
@@ -182,7 +182,10 @@
     "lightSource": {
       "on": false,
       "frequency": 3.3000002,
-      "radiationPeriod": 250
+      "radiationPeriod": 250,
+      "monochromatic": true,
+      "numberOfBeams": 10,
+      "angleOfIncidence": 0
     }
   },
   "useDuration": "codap",

--- a/test/fixtures/mml-conversions/expected-json/rectangles.json
+++ b/test/fixtures/mml-conversions/expected-json/rectangles.json
@@ -1325,7 +1325,15 @@
       ]
     ],
     "photons": {},
-    "radiationlessEmissionProbability": 1
+    "radiationlessEmissionProbability": 1,
+    "lightSource": {
+      "on": false,
+      "frequency": 1,
+      "radiationPeriod": 1000,
+      "monochromatic": true,
+      "numberOfBeams": 10,
+      "angleOfIncidence": 0
+    }
   },
   "useDuration": "codap",
   "requestedDuration": null

--- a/test/fixtures/mml-conversions/expected-json/sunOnGround.json
+++ b/test/fixtures/mml-conversions/expected-json/sunOnGround.json
@@ -1101,7 +1101,8 @@
       "frequency": 13.92,
       "radiationPeriod": 784,
       "numberOfBeams": 5,
-      "angleOfIncidence": -2.6179938
+      "angleOfIncidence": -2.6179938,
+      "monochromatic": true
     }
   },
   "useDuration": "codap",


### PR DESCRIPTION
1. Authors can set `monochromatic` property of a light source.
2. I've added default properties of light source to metadata. I was trying to use Classic MW as a reference. It shouldn't hurt and some of the converted models didn't work without it.

EDIT: okay, I can see I need to update serialization tests.