### PR TITLE
Improved KE shading

### DIFF
--- a/src/lab/models/md2d/models/metadata.js
+++ b/src/lab/models/md2d/models/metadata.js
@@ -194,6 +194,16 @@ define(function() {
         defaultValue: false,
         storeInTickHistory: true
       },
+      keShadingMinEnergy: {
+        // Kinetic energy of an atom which is lower boundary for KE shading (white shading).
+        defaultValue: 0,
+        storeInTickHistory: true
+      },
+      keShadingMaxEnergy: {
+        // Kinetic energy of an atom which is upper boundary for KE shading (red shading).
+        defaultValue: 0.2,
+        storeInTickHistory: true
+      },
       chargeShading: {
         defaultValue: false,
         storeInTickHistory: true

--- a/src/lab/models/md2d/views/atoms-renderer.js
+++ b/src/lab/models/md2d/views/atoms-renderer.js
@@ -313,7 +313,7 @@ define(function(require) {
       },
 
       update: function () {
-        var i, len, viewAtom, modelAtom, x, y;
+        var i, len, viewAtom, modelAtom, x, y, minKE, maxKE;
 
         for (i = 0, len = viewAtoms.length; i < len; ++i) {
           viewAtom = viewAtoms[i];
@@ -331,7 +331,9 @@ define(function(require) {
           }
 
           if (renderMode.keShading) {
-            viewAtom.keSprite.alpha = Math.min(5 * model.getAtomKineticEnergy(i), 1);
+            minKE = model.get('keShadingMinEnergy');
+            maxKE = model.get('keShadingMaxEnergy');
+            viewAtom.keSprite.alpha = Math.min((model.getAtomKineticEnergy(i) - minKE) / (maxKE - minKE), 1);
             viewAtom.keSprite.position.x = x;
             viewAtom.keSprite.position.y = y;
           }

--- a/test/fixtures/mml-conversions/expected-json/angular-bonds.json
+++ b/test/fixtures/mml-conversions/expected-json/angular-bonds.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/custom-element-colors.json
+++ b/test/fixtures/mml-conversions/expected-json/custom-element-colors.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#ff00ff",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/custom-lj-properties.json
+++ b/test/fixtures/mml-conversions/expected-json/custom-lj-properties.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/draggable-atom.json
+++ b/test/fixtures/mml-conversions/expected-json/draggable-atom.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/electric-field.json
+++ b/test/fixtures/mml-conversions/expected-json/electric-field.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/ellipse-alhpa-at-props.json
+++ b/test/fixtures/mml-conversions/expected-json/ellipse-alhpa-at-props.json
@@ -36,6 +36,8 @@
     "showClock": false,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/gravitational-field-100.json
+++ b/test/fixtures/mml-conversions/expected-json/gravitational-field-100.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/gravitational-field-200-default.json
+++ b/test/fixtures/mml-conversions/expected-json/gravitational-field-200-default.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/gravitational-field-400.json
+++ b/test/fixtures/mml-conversions/expected-json/gravitational-field-400.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/gravitational-field-off.json
+++ b/test/fixtures/mml-conversions/expected-json/gravitational-field-off.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/heatbath.json
+++ b/test/fixtures/mml-conversions/expected-json/heatbath.json
@@ -36,6 +36,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/image-layers.json
+++ b/test/fixtures/mml-conversions/expected-json/image-layers.json
@@ -36,6 +36,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/image-visible-and-hidden.json
+++ b/test/fixtures/mml-conversions/expected-json/image-visible-and-hidden.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/immovable-atom.json
+++ b/test/fixtures/mml-conversions/expected-json/immovable-atom.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/invisible-obstacle.json
+++ b/test/fixtures/mml-conversions/expected-json/invisible-obstacle.json
@@ -35,6 +35,8 @@
     "showClock": false,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/mark-atoms.json
+++ b/test/fixtures/mml-conversions/expected-json/mark-atoms.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#ff0033",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/mazeGame.json
+++ b/test/fixtures/mml-conversions/expected-json/mazeGame.json
@@ -35,6 +35,8 @@
     "showClock": false,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/no-atoms.json
+++ b/test/fixtures/mml-conversions/expected-json/no-atoms.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/no-electric-field.json
+++ b/test/fixtures/mml-conversions/expected-json/no-electric-field.json
@@ -35,6 +35,8 @@
     "showClock": false,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/obstacle-color.json
+++ b/test/fixtures/mml-conversions/expected-json/obstacle-color.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/obstacle-mass.json
+++ b/test/fixtures/mml-conversions/expected-json/obstacle-mass.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/obstacle-probes.json
+++ b/test/fixtures/mml-conversions/expected-json/obstacle-probes.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/one-textbox.json
+++ b/test/fixtures/mml-conversions/expected-json/one-textbox.json
@@ -35,6 +35,8 @@
     "showClock": false,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/point-restraint.json
+++ b/test/fixtures/mml-conversions/expected-json/point-restraint.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/quantum-collision.json
+++ b/test/fixtures/mml-conversions/expected-json/quantum-collision.json
@@ -35,6 +35,8 @@
     "showClock": false,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/rectangles.json
+++ b/test/fixtures/mml-conversions/expected-json/rectangles.json
@@ -35,6 +35,8 @@
     "showClock": false,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/show-charge-symbols.json
+++ b/test/fixtures/mml-conversions/expected-json/show-charge-symbols.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/show-vdw-lines.json
+++ b/test/fixtures/mml-conversions/expected-json/show-vdw-lines.json
@@ -35,6 +35,8 @@
     "showClock": false,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/simple-ke-shading.json
+++ b/test/fixtures/mml-conversions/expected-json/simple-ke-shading.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": true,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/solvent-dielectric-constant.json
+++ b/test/fixtures/mml-conversions/expected-json/solvent-dielectric-constant.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/sunOnGround.json
+++ b/test/fixtures/mml-conversions/expected-json/sunOnGround.json
@@ -35,6 +35,8 @@
     "showClock": false,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/target-game-distance.json
+++ b/test/fixtures/mml-conversions/expected-json/target-game-distance.json
@@ -35,6 +35,8 @@
     "showClock": false,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/time-step-5.0.json
+++ b/test/fixtures/mml-conversions/expected-json/time-step-5.0.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading-image.json
+++ b/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading-image.json
@@ -35,6 +35,8 @@
     "showClock": false,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading.json
+++ b/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/two-charged-atoms.json
+++ b/test/fixtures/mml-conversions/expected-json/two-charged-atoms.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/two-diatomic-molecules.json
+++ b/test/fixtures/mml-conversions/expected-json/two-diatomic-molecules.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/two-obstacles.json
+++ b/test/fixtures/mml-conversions/expected-json/two-obstacles.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/vectors.json
+++ b/test/fixtures/mml-conversions/expected-json/vectors.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/view-refresh-interval-10.json
+++ b/test/fixtures/mml-conversions/expected-json/view-refresh-interval-10.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/viscosity-friction.json
+++ b/test/fixtures/mml-conversions/expected-json/viscosity-friction.json
@@ -36,6 +36,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/visible-and-invisible.json
+++ b/test/fixtures/mml-conversions/expected-json/visible-and-invisible.json
@@ -35,6 +35,8 @@
     "showClock": true,
     "markColor": "#f8b500",
     "keShading": false,
+    "keShadingMinEnergy": 0,
+    "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",


### PR DESCRIPTION
Now authors can set energies that correspond to the lower and upper bound of the KE shading.
This change is backward compatible (default values aren't random).