### PR TITLE
Fix a bug in export controller (triggered by missing property description)

### DIFF
--- a/src/lab/common/controllers/export-controller.js
+++ b/src/lab/common/controllers/export-controller.js
@@ -312,11 +312,11 @@ define(function (require) {
 
     function getLabelForProperty(property) {
       var desc  = model.getPropertyDescription(property),
-          label = desc.getLabel(),
-          units = desc.getUnitAbbreviation(),
+          label = desc && desc.getLabel(),
+          units = desc && desc.getUnitAbbreviation(),
           ret   = "";
 
-      if (label.length > 0) {
+      if (label && label.length > 0) {
         ret += label;
       } else {
         ret += property;


### PR DESCRIPTION
I think it's pretty straightforward. In some cases description is not available (iframe model), so export / logging wasn't working.