### PR TITLE
Energy2D: fix calculation of simulation cells taken by shapes

### DIFF
--- a/src/lab/models/energy2d/models/part.js
+++ b/src/lab/models/energy2d/models/part.js
@@ -154,8 +154,8 @@ define(function (require, exports, module) {
     var
       nx1 = nx - 1,
       ny1 = ny - 1,
-      dx = nx1 / lx,
-      dy = ny1 / ly,
+      dx = nx / lx,
+      dy = ny / ly,
 
       rectangleIndices = function (rect) {
         var i, j, i0, j0, i_max, j_max, idx, indices = [];

--- a/src/lab/models/energy2d/views/parts.js
+++ b/src/lab/models/energy2d/views/parts.js
@@ -4,7 +4,7 @@ define(function () {
 
   // Classic version of Energy2D was rendering rectangles with small shift.
   // If we do the same then converted models look better.
-  var E2D_XY_SHIFT = -1,
+  var E2D_XY_SHIFT = 1,
       E2D_DIM_SHIFT = 2;
 
   return function PartsView(SVGContainer, g) {


### PR DESCRIPTION
The PR is necessary to fix this model:
http://lab.concord.org/interactives.html#interactives/energy2d/htb/S5A1.json 
together with a small change to the model itself:
https://github.com/concord-consortium/lab-interactives-site/commit/73a5a1a294ded2566af391c94d169f65c70f9784

Fixed model:
http://lab.concord.org/branch/energy2d-fix/interactives.html#interactives/energy2d/htb/S5A1.json

Short description:
Each part / shape in Energy2D occupies some simulation grid cells. Those cells were calculated incorrectly, so average temperate at the edge of shape was different in Java and JS versions. That was causing incorrect radiation energy, which is based exactly on that.

There was also another issues related to floating point precision which is fixed in the S5A1.JSON itself.

This change seems small, but it can affect other models. Especially when parts are touching each other and energy is transferred between them. I've quickly tested all the models under "Energy2D: Heat Transfer" category and they seem fine.