### PR TITLE
Improve logging, add new event types, cleanup logging & CODAP export

### DIFF
--- a/src/lab/common/controllers/basic-dialog.js
+++ b/src/lab/common/controllers/basic-dialog.js
@@ -8,6 +8,11 @@ define(function () {
     width: "80%"
   };
 
+  // E.g. "interactive-dialog" -> "InteractiveDialog".
+  function titleizeClass(className) {
+    return className.split('-').map(function(s) { return s[0].toUpperCase() + s.slice(1); }).join('');
+  }
+
   /**
    * Simple wrapper around the jQuery UI Dialog,
    * which provides useful defaults and simple interface.
@@ -25,7 +30,9 @@ define(function () {
 
     this.$element = $('<div id="'+id+'" title="'+title+'">');
     // Create jQuery UI Dialog.
-    this.$element.dialog($.extend({closeText: i18n.t("dialog.close_tooltip")}, defOptions, options));
+    options = $.extend({closeText: i18n.t("dialog.close_tooltip")}, defOptions, options)
+    this.$element.dialog(options);
+    this._eventNamePrefix = titleizeClass(options.dialogClass);
   }
 
   /**
@@ -68,6 +75,24 @@ define(function () {
     // http://jqueryui.com/upgrade-guide/1.10/#added-ability-to-specify-which-element-to-focus-on-open
     this.$element.append('<input type="hidden" autofocus="autofocus" />');
     this.$element.append(this.$content);
+  };
+
+  /**
+   * Enables logging.
+   *
+   * @param {function} logFunc function that accepts action name and data
+   */
+  BasicDialog.prototype.enableLogging = function (logFunc) {
+    var openTime = null;
+    var eventNamePrefix = this._eventNamePrefix;
+    this.$element.off('.logging');
+    this.$element.on('dialogopen.logging', function () {
+      logFunc(eventNamePrefix + 'Opened');
+      openTime = Date.now();
+    });
+    this.$element.on('dialogclose.logging', function () {
+      logFunc(eventNamePrefix + 'Closed', {wasOpenFor: (Date.now() - openTime) / 1000});
+    });
   };
 
   return BasicDialog;

--- a/src/lab/common/controllers/button-controller.js
+++ b/src/lab/common/controllers/button-controller.js
@@ -34,7 +34,7 @@ define(function () {
     var comp = this.component;
     this.$element.off("click." + this._nameSpace + "logging");
     this.$element.on("click." + this._nameSpace + "logging", this._clickTargetSelector, function () {
-      logFunc('ButtonClicked', {id: comp.id, text: comp.text});
+      logFunc('ButtonClicked', {id: comp.id, label: comp.text});
     });
   };
 

--- a/src/lab/common/controllers/button-controller.js
+++ b/src/lab/common/controllers/button-controller.js
@@ -19,6 +19,7 @@ define(function () {
     this.setAttributes = function(attrs) {
       // only support text changes right now
       if (attrs.text && typeof(attrs.text) !== "undefined") {
+        this.component.text = attrs.text;
         this.button.html(attrs.text);
       }
     };

--- a/src/lab/common/controllers/button-controller.js
+++ b/src/lab/common/controllers/button-controller.js
@@ -30,13 +30,5 @@ define(function () {
     ButtonController.superClass._modelLoadedCallback.call(this);
   };
 
-  ButtonController.prototype.enableLogging = function (logFunc) {
-    var comp = this.component;
-    this.$element.off("click." + this._nameSpace + "logging");
-    this.$element.on("click." + this._nameSpace + "logging", this._clickTargetSelector, function () {
-      logFunc('ButtonClicked', {id: comp.id, label: comp.text});
-    });
-  };
-
   return ButtonController;
 });

--- a/src/lab/common/controllers/button-controller.js
+++ b/src/lab/common/controllers/button-controller.js
@@ -9,13 +9,13 @@ define(function () {
   function ButtonController(component, interactivesController) {
     this._actionClickFunction = function () { };
     this._nameSpace = "button" + (++buttonControllerCount);
+    this._clickTargetSelector = 'button';
     // Call super constructor.
     InteractiveComponent.call(this, "button", component, interactivesController);
     this.$element.addClass("interactive-button");
     this.button = $('<button>')
         .html(component.text)
         .appendTo(this.$element);
-    this._clickTargetSelector = 'button';
     this.setAttributes = function(attrs) {
       // only support text changes right now
       if (attrs.text && typeof(attrs.text) !== "undefined") {
@@ -30,6 +30,13 @@ define(function () {
     ButtonController.superClass._modelLoadedCallback.call(this);
   };
 
+  ButtonController.prototype.enableLogging = function (logFunc) {
+    var comp = this.component;
+    this.$element.off("click." + this._nameSpace + "logging");
+    this.$element.on("click." + this._nameSpace + "logging", this._clickTargetSelector, function () {
+      logFunc('ButtonClicked', {id: comp.id, text: comp.text});
+    });
+  };
 
   return ButtonController;
 });

--- a/src/lab/common/controllers/checkbox-controller.js
+++ b/src/lab/common/controllers/checkbox-controller.js
@@ -161,6 +161,15 @@ define(function () {
         }
       },
 
+      enableLogging: function (logFunc) {
+        $checkbox.off('change.logging');
+        $checkbox.on('change.logging', function () {
+          var data = {id: component.id, label: component.text, value: $(this).is(':checked')};
+          if (propertyName) data.property = propertyName;
+          logFunc('CheckboxChanged', data);
+        });
+      },
+
       // Returns view container. Label tag, as it contains checkbox anyway.
       getViewContainer: function () {
         return $element;

--- a/src/lab/common/controllers/export-controller.js
+++ b/src/lab/common/controllers/export-controller.js
@@ -178,7 +178,6 @@ define(function (require) {
       model.on('reset.exportController', resetData);
       model.on('play.exportController', function() {
         removeDataAfterStepPointer();
-        logAction("StartedModel", getCurrentPerRunData());
         // Save the per-run parameters we see now -- we'll log if a user changes any parameters
         // before exporting the data
         if (!initialPerRunData) {
@@ -248,9 +247,7 @@ define(function (require) {
         registerModelListeners();
 
         if (eventName === 'modelLoaded') {
-          if (cause === 'reload') {
-            logAction("ReloadedModel", savedPerRunData);
-          } else if (cause === 'new-run') {
+          if (cause === 'new-run') {
             logAction("SetUpNewRun");
           } else {
             logAction("LoadedModel");
@@ -270,7 +267,6 @@ define(function (require) {
           modelCanExportData = true;
           dispatch.modelCanExportData();
         }
-
       }
 
       modelCanExportData = false;

--- a/src/lab/common/controllers/export-controller.js
+++ b/src/lab/common/controllers/export-controller.js
@@ -6,12 +6,7 @@ define(function (require) {
   var dgExporter = require('import-export/dg-exporter');
   var BasicDialog = require('common/controllers/basic-dialog');
   var DispatchSupport = require('common/dispatch-support');
-  var iframePhone = require('iframe-phone');
   var _ = require('underscore');
-
-  var canLogData = false;
-  var laraLoggerPresent = false;
-  var laraPhone;
 
   function modalAlert(title, message, buttons, i18n) {
     var dialog = new BasicDialog({
@@ -283,17 +278,10 @@ define(function (require) {
       // Don't accumulate data or logs until we know we know there is somewhere to send the data.
       // (Note that CODAP, if present, will announce itself before the model can be started by the
       // user, so there should not be data loss.)
-      if (controller.canExportData() || controller.canLogData()) {
+      if (controller.canExportData()) {
         handleModelLoaded();
       } else {
         controller.on('canExportData.export-controller', handleModelLoaded);
-        controller.on('canLogData.export-controller', function() {
-          // canExport implies canLog, so only call handleModelLoaded here if we can log but not
-          // export. Otherwise, we would call it twice every time canExportData is emitted.
-          if ( ! controller.canExportData() ) {
-            handleModelLoaded();
-          }
-        });
       }
     }
 
@@ -336,10 +324,6 @@ define(function (require) {
       // whether or not there is CODAP or some other data sink is present and listening for data)
       canExportData: function() {
         return ExportController.canExportData();
-      },
-
-      canLogData: function() {
-        return ExportController.canLogData();
       },
 
       modelCanExportData: function() {
@@ -447,32 +431,16 @@ define(function (require) {
     // Issue an 'canExportData' event when canExportData() flips from false to true.
     // Issue 'modelCanExportData' when modelCanExportData() flips
     dispatch.mixInto(controller);
-    dispatch.addEventTypes('canExportData', 'modelCanExportData', 'canLogData');
+    dispatch.addEventTypes('canExportData', 'modelCanExportData');
 
     // Make sure we emit event if canExportData becomes true. Assume codap connects only once.
     dgExporter.codapDidConnect = function() {
       if ( ExportController.canExportData() ) {
         dispatch.canExportData();
-        dispatch.canLogData();
       }
     };
 
     registerInteractiveListeners();
-
-    // Listen for new
-    // Will automatically reuse existing iframePhone because we're in a child window
-    laraPhone = new iframePhone.IframePhoneRpcEndpoint(
-      function (message, callback) {
-          if ( ! canLogData && message && message.message === 'lara-logging-present' ) {
-            canLogData = true;
-            laraLoggerPresent = true;
-            dispatch.canLogData();
-          }
-          callback();
-        },
-        'lara-logging',
-        window.parent
-      );
 
     return controller;
   }
@@ -482,21 +450,8 @@ define(function (require) {
     return dgExporter.canExportData();
   };
 
-  ExportController.canLogData = function() {
-    return canLogData || ExportController.canExportData();
-  };
-
   ExportController.logAction = function(logString) {
     dgExporter.logAction.apply(dgExporter, arguments);
-    if (laraLoggerPresent) {
-      // Legacy of CODAP
-      laraPhone.call({
-        action: 'logAction',
-        args: {
-          formatStr: logString
-        }
-      });
-    }
   };
 
   return ExportController;

--- a/src/lab/common/controllers/help-system.js
+++ b/src/lab/common/controllers/help-system.js
@@ -258,6 +258,18 @@ define(function (require) {
 
       hasShowcase: function () {
         return helpTips.filter(function(h) { return h.showcase }).length > 0;
+      },
+
+      enableLogging: function(logFunc) {
+        var startTime = null;
+        dispatch.on('.logging', null);
+        dispatch.on('start.logging', function () {
+          logFunc('HelpTipsOpened');
+          startTime = Date.now();
+        });
+        dispatch.on('stop.logging', function () {
+          logFunc('HelpTipsClosed', {wasOpenFor: (Date.now() - startTime) / 1000});
+        });
       }
     };
 

--- a/src/lab/common/controllers/interactive-component.js
+++ b/src/lab/common/controllers/interactive-component.js
@@ -118,9 +118,8 @@ define(function (require) {
     if (comp.onClick === undefined && comp.action === undefined) return; // nothing to log
     var eventName = comp.type[0].toUpperCase() + comp.type.slice(1) + "Clicked";
     var data = {id: comp.id};
-    var label = comp.label || comp.text || comp.title;
-    if (label) data.label = label;
     this._onClick(this._nameSpace + "logging", function () {
+      data.label = comp.label || comp.text || comp.title;
       logFunc(eventName, data);
     });
   };

--- a/src/lab/common/controllers/interactive-component.js
+++ b/src/lab/common/controllers/interactive-component.js
@@ -72,8 +72,6 @@ define(function (require) {
   };
 
   InteractiveComponent.prototype._updateClickHandler = function (script) {
-    // always discard attached click handler
-    this.$element.off("click."+this._nameSpace);
     // Create a new handler function from action or onClick in string form
     if (typeof script !== "function") {
       this._actionClickFunction = this._scriptingAPI.makeFunctionInScriptContext(script);
@@ -81,7 +79,7 @@ define(function (require) {
       this._actionClickFunction = script;
     }
     var that = this;
-    this.$element.on("click."+this._nameSpace, this._clickTargetSelector || null, function() {
+    this._onClick(this._nameSpace, function() {
       that._actionClickFunction();
     });
     // Also add a special class indicating that this text node is a clickable.
@@ -115,6 +113,18 @@ define(function (require) {
     }
   };
 
+  InteractiveComponent.prototype.enableLogging = function (logFunc) {
+    var comp = this.component;
+    if (comp.onClick === undefined && comp.action === undefined) return; // nothing to log
+    var eventName = comp.type[0].toUpperCase() + comp.type.slice(1) + "Clicked";
+    var data = {id: comp.id};
+    var label = comp.label || comp.text || comp.title;
+    if (label) data.label = label;
+    this._onClick(this._nameSpace + "logging", function () {
+      logFunc(eventName, data);
+    });
+  };
+
   /**
    * @return {jQuery} The most outer element.
    */
@@ -127,6 +137,11 @@ define(function (require) {
    */
   InteractiveComponent.prototype.serialize = function() {
     return this.component;
+  };
+
+  InteractiveComponent.prototype._onClick = function(namespace, handler) {
+    this.$element.off("click." + namespace);
+    this.$element.on("click." + namespace, this._clickTargetSelector || null, handler);
   };
 
   // It will add .setDisabled() method to the prototype.

--- a/src/lab/common/controllers/interactive-metadata.js
+++ b/src/lab/common/controllers/interactive-metadata.js
@@ -145,6 +145,10 @@ define(function() {
         required: false
       },
 
+      logging: {
+        required: false
+      },
+
       components: {
         // List of the interactive components. Their definitions are below ('button', 'checkbox' etc.).
         defaultValue: []
@@ -286,6 +290,26 @@ define(function() {
       },
       perTick: {
         required: true
+      }
+    },
+
+    logging: {
+      onStart: {
+        defaultValue: true
+      },
+      onStop: {
+        defaultValue: true
+      },
+      onReload: {
+        defaultValue: true
+      },
+      properties: {
+        // Properties that are logged on start, stop and reload events.
+        defaultValue: []
+      },
+      components: {
+        // Names of components which should log user interaction.
+        defaultValue: []
       }
     },
 

--- a/src/lab/common/controllers/interactive-metadata.js
+++ b/src/lab/common/controllers/interactive-metadata.js
@@ -294,13 +294,10 @@ define(function() {
     },
 
     logging: {
-      onStart: {
-        defaultValue: true
-      },
-      onStop: {
-        defaultValue: true
-      },
-      onReload: {
+      enabled: {
+        // Global logging switch. Model start, stop and reload are be logged by default
+        // (and probably some other events in the future). Also, #logAction scripting API function
+        // works only if it's set to true.
         defaultValue: true
       },
       properties: {

--- a/src/lab/common/controllers/interactive-metadata.js
+++ b/src/lab/common/controllers/interactive-metadata.js
@@ -146,6 +146,9 @@ define(function() {
       },
 
       logging: {
+        // Note that logging is enabled by default, even if configuration is not provided. Take a look at
+        // logging section below to see the default configuration. To disable logging, you need to explicitly
+        // provide config with "enabled" property set to false.
         required: false
       },
 
@@ -302,7 +305,8 @@ define(function() {
       },
       properties: {
         // Properties that are logged on start, stop and reload events.
-        defaultValue: []
+        // "boundToComponents" is a special value for authors' convenience.
+        defaultValue: "boundToComponents"
       },
       components: {
         // List of components which should log user interaction.

--- a/src/lab/common/controllers/interactive-metadata.js
+++ b/src/lab/common/controllers/interactive-metadata.js
@@ -305,8 +305,9 @@ define(function() {
         defaultValue: []
       },
       components: {
-        // Names of components which should log user interaction.
-        defaultValue: []
+        // List of components which should log user interaction.
+        // "all" and "none" are special values for authors' convenience.
+        defaultValue: "all"
       }
     },
 

--- a/src/lab/common/controllers/interactives-controller.js
+++ b/src/lab/common/controllers/interactives-controller.js
@@ -302,7 +302,7 @@ define(function (require) {
       // The authored definition of which components go in which container.
       layout = interactive.layout;
 
-      // Banner hash containing components, layout containers and layout deinition
+      // Banner hash containing components, layout containers and layout definition
       // (components location). Keep it in a separate structure, because we do not
       // expect these objects to be serialized!
       banner = setupBanner(controller, interactive, creditsDialog, aboutDialog, shareDialog);

--- a/src/lab/common/controllers/interactives-controller.js
+++ b/src/lab/common/controllers/interactives-controller.js
@@ -198,7 +198,7 @@ define(function (require) {
         randSeed,
 
         dispatch = new DispatchSupport("modelLoaded", "interactiveRendered", "modelReset", "resize",
-                                       "interactiveRequested");
+                                       "interactiveRequested", "interactiveWillReload");
 
     // simple tabindex support, also exposed via api.getNextTabIndex()
     getNextTabIndex = function () {
@@ -713,9 +713,15 @@ define(function (require) {
 
       exportController = new ExportController(controller);
 
-      // Use logging config if provided or use default one (validation will fill an empty hash with default values).
-      var loggingConfig = interactive.logging || validator.validateCompleteness(metadata.logging, {});
-      logController = new LogController(loggingConfig, controller, componentByID, getBoundProperties());
+      logController = new LogController({
+        // Use logging config if provided or use default one (validation will fill an empty hash with default values).
+        config: interactive.logging || validator.validateCompleteness(metadata.logging, {}),
+        componentByID: componentByID,
+        // List of components that implement .enableLogging() method and should have logging enabled by default.
+        additionalComponents: [aboutDialog, shareDialog, creditsDialog, helpSystem],
+        boundProperties: getBoundProperties(),
+        interactivesController: controller
+      });
 
       // Setup experimentController, if defined.
       if (interactive.experiment) {
@@ -1355,6 +1361,7 @@ define(function (require) {
       reloadInteractive: function() {
         model.stop();
         notifyWillResetModelAnd(function() {
+          dispatch.interactiveWillReload();
           controller.loadInteractive(initialInteractiveConfig);
         });
       },

--- a/src/lab/common/controllers/interactives-controller.js
+++ b/src/lab/common/controllers/interactives-controller.js
@@ -1427,6 +1427,19 @@ define(function (require) {
         });
       },
 
+      /**
+       * Logs custom event specified by author. Note that logging needs to be enabled in interactive JSON!
+       * It means 'logging' hash needs to be specified, it can be even empty.
+       * Log message will be sent to parent window, so parent window needs to handle it.
+       * Currently, only LARA does it and sends logs to CC Log Manager App.
+       *
+       * @param {string} actionName
+       * @param {object} data Hash of key-values that should be logged.
+       */
+      logAction: function(actionName, data) {
+        logController && logController.logAction(actionName, data);
+      },
+
       updateModelView: function() {
         modelController.updateView();
       },

--- a/src/lab/common/controllers/interactives-controller.js
+++ b/src/lab/common/controllers/interactives-controller.js
@@ -1429,7 +1429,7 @@ define(function (require) {
 
       /**
        * Logs custom event specified by author. Note that logging needs to be enabled in interactive JSON!
-       * It means 'logging' hash needs to be specified, it can be even empty.
+       * It means "logging": {"enabled": true} needs to be specified.
        * Log message will be sent to parent window, so parent window needs to handle it.
        * Currently, only LARA does it and sends logs to CC Log Manager App.
        *

--- a/src/lab/common/controllers/interactives-controller.js
+++ b/src/lab/common/controllers/interactives-controller.js
@@ -16,6 +16,7 @@ define(function (require) {
       BarGraphController      = require('common/controllers/bar-graph-controller'),
       GraphController         = require('common/controllers/graph-controller'),
       ExportController        = require('common/controllers/export-controller'),
+      LogController           = require('common/controllers/log-controller'),
       ScriptingAPI            = require('common/controllers/scripting-api'),
       ButtonController        = require('common/controllers/button-controller'),
       CheckboxController      = require('common/controllers/checkbox-controller'),
@@ -180,6 +181,9 @@ define(function (require) {
 
         // Handles exporting data to DataGames, if 'exports' are specified.
         exportController,
+
+        // Handles logging events to LARA or any parent that implements LARA-logging interface.
+        logController,
 
         // Doesn't currently have any public methods, but probably will.
         parentMessageAPI,
@@ -489,6 +493,14 @@ define(function (require) {
         }
       }
 
+      try {
+        interactive.logging = validator.validateCompleteness(metadata.logging, interactive.logging || {});
+      } catch (e) {
+        errMsg = "Incorrect logging definition:\n" + e.message;
+        alert(errMsg);
+        throw new Error(errMsg);
+      }
+
       return interactive;
     }
 
@@ -698,6 +710,8 @@ define(function (require) {
       // result that exportController.canExportData never becomes true)
 
       exportController = new ExportController(controller);
+
+      logController = new LogController(interactive.logging, controller);
 
       // Setup experimentController, if defined.
       if (interactive.experiment) {

--- a/src/lab/common/controllers/interactives-controller.js
+++ b/src/lab/common/controllers/interactives-controller.js
@@ -714,7 +714,7 @@ define(function (require) {
       exportController = new ExportController(controller);
 
       if (interactive.logging) {
-        logController = new LogController(interactive.logging, controller);
+        logController = new LogController(interactive.logging, controller, componentByID);
       }
 
       // Setup experimentController, if defined.

--- a/src/lab/common/controllers/interactives-controller.js
+++ b/src/lab/common/controllers/interactives-controller.js
@@ -495,7 +495,7 @@ define(function (require) {
 
       if (interactive.logging) {
         try {
-          interactive.logging = validator.validateCompleteness(metadata.logging, interactive.logging || {});
+          interactive.logging = validator.validateCompleteness(metadata.logging, interactive.logging);
         } catch (e) {
           errMsg = "Incorrect logging definition:\n" + e.message;
           alert(errMsg);
@@ -713,9 +713,9 @@ define(function (require) {
 
       exportController = new ExportController(controller);
 
-      if (interactive.logging) {
-        logController = new LogController(interactive.logging, controller, componentByID);
-      }
+      // Use logging config if provided or use default one (validation will fill an empty hash with default values).
+      var loggingConfig = interactive.logging || validator.validateCompleteness(metadata.logging, {});
+      logController = new LogController(loggingConfig, controller, componentByID, getBoundProperties());
 
       // Setup experimentController, if defined.
       if (interactive.experiment) {

--- a/src/lab/common/controllers/interactives-controller.js
+++ b/src/lab/common/controllers/interactives-controller.js
@@ -493,12 +493,14 @@ define(function (require) {
         }
       }
 
-      try {
-        interactive.logging = validator.validateCompleteness(metadata.logging, interactive.logging || {});
-      } catch (e) {
-        errMsg = "Incorrect logging definition:\n" + e.message;
-        alert(errMsg);
-        throw new Error(errMsg);
+      if (interactive.logging) {
+        try {
+          interactive.logging = validator.validateCompleteness(metadata.logging, interactive.logging || {});
+        } catch (e) {
+          errMsg = "Incorrect logging definition:\n" + e.message;
+          alert(errMsg);
+          throw new Error(errMsg);
+        }
       }
 
       return interactive;
@@ -711,7 +713,9 @@ define(function (require) {
 
       exportController = new ExportController(controller);
 
-      logController = new LogController(interactive.logging, controller);
+      if (interactive.logging) {
+        logController = new LogController(interactive.logging, controller);
+      }
 
       // Setup experimentController, if defined.
       if (interactive.experiment) {

--- a/src/lab/common/controllers/interactives-controller.js
+++ b/src/lab/common/controllers/interactives-controller.js
@@ -1569,6 +1569,10 @@ define(function (require) {
           result.exports = $.extend(true, {}, interactive.exports);
         }
 
+        if (interactive.logging !== undefined) {
+          result.logging = $.extend(true, {}, interactive.logging);
+        }
+
         if (interactive.experiment !== undefined) {
           result.experiment = $.extend(true, {}, interactive.experiment);
         }

--- a/src/lab/common/controllers/log-controller.js
+++ b/src/lab/common/controllers/log-controller.js
@@ -46,7 +46,9 @@ define(function (require) {
 
     var logString = action;
     // Weird format, CODAP legacy. But it works.
-    if (data) logString += ': ' + JSON.stringify(data);
+    // LARA doesn't accept logs if they don't include ":" character. Make sure it's always present.
+    // Once this https://github.com/concord-consortium/lara/pull/137 is merged, it's no longer important.
+    logString += ': ' + JSON.stringify(data || {});
 
     this._logToLARA(logString);
     this._logToCODAP(logString);

--- a/src/lab/common/controllers/log-controller.js
+++ b/src/lab/common/controllers/log-controller.js
@@ -102,6 +102,11 @@ define(function (require) {
   LogController.prototype._modelLoadedHandler = function (cause) {
     this._model = this._interactivesController.getModel();
 
+    this._model.on('log.logController', function (action, data) {
+      // Models can log custom events too using dispatch. Just pass them to the parent.
+      this.logAction(action, data);
+    }.bind(this));
+
     this._model.on('play.logController', function () {
       this.logAction('StartedModel', this._getProperties());
     }.bind(this));

--- a/src/lab/common/controllers/log-controller.js
+++ b/src/lab/common/controllers/log-controller.js
@@ -1,0 +1,98 @@
+/*global define*/
+/*jslint boss: true*/
+
+define(function (require) {
+  var iframePhone = require('iframe-phone');
+
+  // Keep iframe phone and parentLoggerReady global. We need to reuse a single iframe phone.
+  // Parent logger doesn't care whether interactive or model has been reloaded, it just expects messages.
+  // Also, it sends 'lara-logging-present' message just once.
+  var _phone = null;
+  var parentLoggerReady = false;
+  function getPhone() {
+    if (!_phone) {
+      _phone = new iframePhone.IframePhoneRpcEndpoint(function (message, callback) {
+        if (message && message.message === 'lara-logging-present') {
+          parentLoggerReady = true;
+        }
+        callback();
+      }, 'lara-logging', window.parent);
+    }
+    return _phone;
+  }
+
+  function LogController(config, interactivesController) {
+    this._config = config;
+    this._interactivesController = interactivesController;
+    this._model = null;
+    this._phone = getPhone();
+
+    this._interactivesController.on('modelLoaded.logController', this._modelLoadedHandler.bind(this));
+  }
+
+  LogController.prototype.logAction = function (action, data) {
+    // Phone might not be initialized yet. In theory we can miss some interaction, but in practice it's
+    // not possible that user interacts with Lab before communication between Lab and parent is initialized.
+    // Also, even if it was possible, we couldn't do much about it.
+    if (!parentLoggerReady) return;
+
+    var logString = action;
+    // Weird format, CODAP legacy. But it works.
+    if (data) logString += ': ' + JSON.stringify(data);
+    this._phone.call({
+      action: 'logAction',
+      args: {
+        formatStr: logString
+      }
+    });
+  };
+
+  LogController.prototype._modelLoadedHandler = function (cause) {
+    this._model = this._interactivesController.getModel();
+
+    this._model.on('play.logController', function () {
+      this.logAction('StartedModel', this._getProperties());
+    }.bind(this));
+
+    this._model.on('stop.logController', function () {
+      this.logAction('StoppedModel', this._getProperties());
+    }.bind(this));
+
+    var savedParameters = null;
+    this._model.on('willReset.logController', function() {
+      savedParameters = this._getProperties();
+    }.bind(this));
+
+    if (cause === 'reload') {
+      this.logAction('ReloadedModel', savedParameters);
+    }
+  };
+
+
+  LogController.prototype._getProperties = function () {
+    var model = this._model;
+    var propData = {};
+    function getLabelForProperty(property) {
+      var desc = model.getPropertyDescription(property);
+      var label = desc && desc.getLabel();
+      var units = desc && desc.getUnitAbbreviation();
+      var ret   = "";
+      if (label && label.length > 0) {
+        ret += label;
+      } else {
+        ret += property;
+      }
+      if (units && units.length > 0) {
+        ret += " (" + units + ")";
+      }
+      return ret;
+    }
+
+    this._config.properties.forEach(function (prop) {
+      propData[getLabelForProperty(prop)] = model.get(prop)
+    });
+    return propData;
+  };
+
+  return LogController;
+});

--- a/src/lab/common/controllers/log-controller.js
+++ b/src/lab/common/controllers/log-controller.js
@@ -22,6 +22,7 @@ define(function (require) {
     return _phone;
   }
 
+  // Handles logging of events to LARA or CODAP.
   function LogController(config, interactivesController, componentByID, propertiesBoundToComponents) {
     this._config = config;
     this._interactivesController = interactivesController;
@@ -94,13 +95,13 @@ define(function (require) {
       this.logAction('StoppedModel', this._getProperties());
     }.bind(this));
 
-    var savedParameters = null;
+    var savedProperties = null;
     this._model.on('willReset.logController', function() {
-      savedParameters = this._getProperties();
+      savedProperties = this._getProperties();
     }.bind(this));
 
     if (cause === 'reload') {
-      this.logAction('ReloadedModel', savedParameters);
+      this.logAction('ReloadedModel', savedProperties);
     }
   };
 

--- a/src/lab/common/controllers/log-controller.js
+++ b/src/lab/common/controllers/log-controller.js
@@ -35,7 +35,7 @@ define(function (require) {
     // Phone might not be initialized yet. In theory we can miss some interaction, but in practice it's
     // not possible that user interacts with Lab before communication between Lab and parent is initialized.
     // Also, even if it was possible, we couldn't do much about it.
-    if (!parentLoggerReady) return;
+    if (!parentLoggerReady || !this._config.enabled) return;
 
     var logString = action;
     // Weird format, CODAP legacy. But it works.

--- a/src/lab/common/controllers/log-controller.js
+++ b/src/lab/common/controllers/log-controller.js
@@ -21,13 +21,14 @@ define(function (require) {
     return _phone;
   }
 
-  function LogController(config, interactivesController) {
+  function LogController(config, interactivesController, componentByID) {
     this._config = config;
     this._interactivesController = interactivesController;
     this._model = null;
     this._phone = getPhone();
 
     this._interactivesController.on('modelLoaded.logController', this._modelLoadedHandler.bind(this));
+    this._setupComponents(componentByID);
   }
 
   LogController.prototype.logAction = function (action, data) {
@@ -43,6 +44,17 @@ define(function (require) {
       action: 'logAction',
       args: {
         formatStr: logString
+      }
+    });
+  };
+
+  LogController.prototype._setupComponents = function (componentByID) {
+    var logFunction = this.logAction.bind(this);
+    this._config.components.forEach(function (compID) {
+      var comp = componentByID[compID];
+      // Enable logging and provide function that component can use to log its own events.
+      if (comp.enableLogging) {
+        comp.enableLogging(logFunction);
       }
     });
   };

--- a/src/lab/common/controllers/log-controller.js
+++ b/src/lab/common/controllers/log-controller.js
@@ -21,9 +21,11 @@ define(function (require) {
     return _phone;
   }
 
-  function LogController(config, interactivesController, componentByID) {
+  function LogController(config, interactivesController, componentByID, propertiesBoundToComponents) {
     this._config = config;
     this._interactivesController = interactivesController;
+    // Use either provided list of properties bound to components (widgets) or list specified explicitly in config.
+    this._properties = config.properties === 'boundToComponents' ? propertiesBoundToComponents : config.properties;
     this._model = null;
     this._phone = getPhone();
 
@@ -107,7 +109,7 @@ define(function (require) {
       return ret;
     }
 
-    this._config.properties.forEach(function (prop) {
+    this._properties.forEach(function (prop) {
       propData[getLabelForProperty(prop)] = model.get(prop)
     });
     return propData;

--- a/src/lab/common/controllers/log-controller.js
+++ b/src/lab/common/controllers/log-controller.js
@@ -49,8 +49,13 @@ define(function (require) {
   };
 
   LogController.prototype._setupComponents = function (componentByID) {
+    var components = this._config.components;
+    if (components === 'none' || components === []) return;
+    if (components === 'all') {
+      components = Object.keys(componentByID);
+    }
     var logFunction = this.logAction.bind(this);
-    this._config.components.forEach(function (compID) {
+    components.forEach(function (compID) {
       var comp = componentByID[compID];
       // Enable logging and provide function that component can use to log its own events.
       if (comp.enableLogging) {

--- a/src/lab/common/controllers/log-controller.js
+++ b/src/lab/common/controllers/log-controller.js
@@ -55,6 +55,8 @@ define(function (require) {
       // Enable logging and provide function that component can use to log its own events.
       if (comp.enableLogging) {
         comp.enableLogging(logFunction);
+      } else {
+        alert('Warning: component ' + compID + ' does not support logging!');
       }
     });
   };

--- a/src/lab/common/controllers/log-controller.js
+++ b/src/lab/common/controllers/log-controller.js
@@ -78,8 +78,6 @@ define(function (require) {
       // Enable logging and provide function that component can use to log its own events.
       if (comp.enableLogging) {
         comp.enableLogging(logFunction);
-      } else {
-        alert('Warning: component ' + compID + ' does not support logging!');
       }
     });
   };

--- a/src/lab/common/controllers/pulldown-controller.js
+++ b/src/lab/common/controllers/pulldown-controller.js
@@ -15,6 +15,8 @@ define(function () {
     var controller,
         model,
         scriptingAPI,
+        // Logging function, can be injected by #enableLogging call.
+        logAction,
         // Options definitions from component JSON definition.
         options,
         view,
@@ -29,6 +31,17 @@ define(function () {
     function updatePulldownDisabledState() {
       var description = model.getPropertyDescription(component.property);
       controller.setDisabled(description.getFrozen());
+    }
+
+    function logChange(optionSpec) {
+      if (!logAction) return; // logging is not enabled
+      var data = {id: component.id, selected: optionSpec.text};
+      if (component.label) data.label = component.label;
+      if (component.property) {
+        data.property = component.property;
+        data.value = optionSpec.value;
+      }
+      logAction('PulldownChanged', data);
     }
 
     function initialize() {
@@ -57,6 +70,7 @@ define(function () {
           } else if (option.value !== undefined) {
             scriptingAPI.api.set(component.property, option.value);
           }
+          logChange(option);
         }
       });
 
@@ -92,6 +106,10 @@ define(function () {
           model = interactivesController.getModel();
         }
         updatePulldown();
+      },
+
+      enableLogging: function (logFunc) {
+        logAction = logFunc;
       },
 
       // Returns view container.

--- a/src/lab/common/controllers/radio-controller.js
+++ b/src/lab/common/controllers/radio-controller.js
@@ -64,13 +64,8 @@ define(function () {
         $options[i].removeClass('checked');
       }
 
-      if ($input.attr('checked') !== undefined) {
-        $input.removeAttr('checked');
-        $span.removeClass('checked');
-      } else {
-        $input.attr('checked', 'checked');
-        $span.addClass('checked');
-      }
+      $input.attr('checked', 'checked');
+      $span.addClass('checked');
 
       // Trigger change event!
       $input.trigger('change');
@@ -182,6 +177,22 @@ define(function () {
         }
         // Perform initial radio setup.
         updateRadio();
+      },
+
+      enableLogging: function (logFunc) {
+        $inputs.forEach(function ($input, idx) {
+          var optionSpec = options[idx];
+          $input.off('.logging');
+          $input.on('change.logging', function () {
+            var data = {id: component.id, selected: optionSpec.text};
+            if (component.label) data.label = component.label;
+            if (component.property) {
+              data.property = component.property;
+              data.value = optionSpec.value;
+            }
+            logFunc('RadioChanged', data);
+          });
+        });
       },
 
       // Returns view container.

--- a/src/lab/common/controllers/scripting-api.js
+++ b/src/lab/common/controllers/scripting-api.js
@@ -160,6 +160,19 @@ define(function (require) {
             return model.unfreeze.apply(model, arguments);
           },
 
+          /**
+           * Logs custom event specified by author. Note that logging needs to be enabled in interactive JSON!
+           * It means 'logging' hash needs to be specified, it can be even empty.
+           * Log message will be sent to parent window, so parent window needs to handle it.
+           * Currently, only LARA does it and sends logs to CC Log Manager App.
+           *
+           * @param {string} actionName
+           * @param {object} data Hash of key-values that should be logged.
+           */
+          logAction: function logAction(actionName, data) {
+            interactivesController.logAction(actionName, data);
+          },
+
           // optional 'parameters' list of values to pass into the loaded model
           //
           // TODO remove optional parameter list when interactives have parameters that

--- a/src/lab/common/controllers/scripting-api.js
+++ b/src/lab/common/controllers/scripting-api.js
@@ -162,7 +162,7 @@ define(function (require) {
 
           /**
            * Logs custom event specified by author. Note that logging needs to be enabled in interactive JSON!
-           * It means 'logging' hash needs to be specified, it can be even empty.
+           * It means "logging": {"enabled": true} needs to be specified.
            * Log message will be sent to parent window, so parent window needs to handle it.
            * Currently, only LARA does it and sends logs to CC Log Manager App.
            *

--- a/src/lab/common/controllers/setup-banner.js
+++ b/src/lab/common/controllers/setup-banner.js
@@ -126,7 +126,7 @@ define(function () {
           "text": controller.i18n.t("banner.share"),
           "onClick": function () {
             shareDialog.open();
-            controller.logAction('ShareDialogStarted');
+            controller.logAction('ShareDialogOpened');
           },
           "tooltip": i18n.t("banner.share_tooltip")
         },

--- a/src/lab/common/controllers/setup-banner.js
+++ b/src/lab/common/controllers/setup-banner.js
@@ -97,6 +97,7 @@ define(function () {
         "text": i18n.t("banner.about"),
         "onClick": function () {
           aboutDialog.open();
+          controller.logAction('AboutDialogOpened');
         },
         "tooltip": i18n.t("banner.about_tooltip")
       },
@@ -123,7 +124,10 @@ define(function () {
           "type": "text",
           "id": "share-link",
           "text": controller.i18n.t("banner.share"),
-          "onClick": function () { shareDialog.open(); },
+          "onClick": function () {
+            shareDialog.open();
+            controller.logAction('ShareDialogStarted');
+          },
           "tooltip": i18n.t("banner.share_tooltip")
         },
         {
@@ -146,6 +150,7 @@ define(function () {
         "content": '<i class="icon-repeat"></i>',
         "onClick": function () {
           controller.reloadInteractive();
+          controller.logAction('InteractiveReloaded');
         },
         "tooltip": i18n.t("banner.reload_tooltip")
       },
@@ -170,6 +175,7 @@ define(function () {
           "onClick": function () {
             if (!controller.helpSystem.isActive()) {
               controller.helpSystem.start();
+              controller.logAction('HelpTipsOpened');
             } else {
               controller.helpSystem.stop();
             }
@@ -223,6 +229,7 @@ define(function () {
         "tooltip": i18n.t("banner.credits_tooltip"),
         "onClick": function () {
           creditsDialog.open();
+          controller.logAction('CreditsDialogOpened');
         }
       },
       {
@@ -275,6 +282,7 @@ define(function () {
           "onClick": function () {
             if (!isFullscreen()) {
               requestFullscreenMethod.call(body);
+              controller.logAction('FullScreenStarted');
             } else {
               document.cancelFullscreenMethod();
             }

--- a/src/lab/common/controllers/setup-banner.js
+++ b/src/lab/common/controllers/setup-banner.js
@@ -97,7 +97,6 @@ define(function () {
         "text": i18n.t("banner.about"),
         "onClick": function () {
           aboutDialog.open();
-          controller.logAction('AboutDialogOpened');
         },
         "tooltip": i18n.t("banner.about_tooltip")
       },
@@ -126,7 +125,6 @@ define(function () {
           "text": controller.i18n.t("banner.share"),
           "onClick": function () {
             shareDialog.open();
-            controller.logAction('ShareDialogOpened');
           },
           "tooltip": i18n.t("banner.share_tooltip")
         },
@@ -150,7 +148,6 @@ define(function () {
         "content": '<i class="icon-repeat"></i>',
         "onClick": function () {
           controller.reloadInteractive();
-          controller.logAction('InteractiveReloaded');
         },
         "tooltip": i18n.t("banner.reload_tooltip")
       },
@@ -175,7 +172,6 @@ define(function () {
           "onClick": function () {
             if (!controller.helpSystem.isActive()) {
               controller.helpSystem.start();
-              controller.logAction('HelpTipsOpened');
             } else {
               controller.helpSystem.stop();
             }
@@ -229,7 +225,6 @@ define(function () {
         "tooltip": i18n.t("banner.credits_tooltip"),
         "onClick": function () {
           creditsDialog.open();
-          controller.logAction('CreditsDialogOpened');
         }
       },
       {

--- a/src/lab/common/lab-modeler-mixin.js
+++ b/src/lab/common/lab-modeler-mixin.js
@@ -96,7 +96,7 @@ define(function (require) {
 
     // FIXME: These events have to be available as some other modules try to
     // add listeners. Probably they aren't necessary, trace it and fix.
-    dispatchSupport.addEventTypes("reset", "stepForward", "stepBack", "seek", "invalidation", "willReset", "ready");
+    dispatchSupport.addEventTypes("reset", "stepForward", "stepBack", "seek", "invalidation", "willReset", "ready", "log");
 
     api = {
       mixInto: function(target) {

--- a/src/lab/common/playback-support.js
+++ b/src/lab/common/playback-support.js
@@ -140,6 +140,7 @@ define(function (require) {
             // See: https://github.com/mbostock/d3/wiki/Transitions#wiki-d3_timer)
             if (stopRequest) {
               stopped = true;
+              if (eventsSupported) dispatch.stop();
               return true;
             }
 
@@ -175,7 +176,6 @@ define(function (require) {
 
         target.stop = function() {
           stopRequest = true;
-          if (eventsSupported) dispatch.stop();
           return target;
         };
 

--- a/src/lab/import-export/dg-exporter.js
+++ b/src/lab/import-export/dg-exporter.js
@@ -65,6 +65,7 @@ define(function(require) {
     isCodapPresent: false,
 
     init: function() {
+      if (this.codapPhone) return; // nothing to initialize
       this.codapPhone = new iframePhone.IframePhoneRpcEndpoint(
         codapCallbackHandler.bind(this),
         "codap-game",

--- a/src/lab/models/iframe/modeler.js
+++ b/src/lab/models/iframe/modeler.js
@@ -56,11 +56,11 @@ define(function(require) {
     // the playback controller assumes 'play' and 'stop' are defined even if the viewOptions
     // disable these buttons
     // the outer iframe in the interactives browser expects a 'reset', 'stepForward', 'stepBack' event type
-    this._dispatch.addEventTypes('tick', 'tickStart', 'tickEnd', 'play', 'stop', 'reset', 'stepForward', 'stepBack');
+    this._dispatch.addEventTypes('tick', 'tickStart', 'tickEnd', 'play', 'stop', 'reset', 'stepForward', 'stepBack', 'log');
 
     // HACK to play with properties
     this.defineParameter('pressure', {
-      label: 'Pressure',
+      label: 'Pressure'
     }, undefined);
     // END OF HACK
   }
@@ -198,14 +198,11 @@ define(function(require) {
       context._dispatch.tick();
     });
 
-    // HACK to play with properties
-    this._phone.addListener('propertyValue', function (content) {
-      if (content.name === 'pressureProbeFiltered') {
-        context.set('pressure', content.value);
-      }
+    // Support logging provided by inner frame. Dispatch 'log' event,
+    // as LogController listens to this event type.
+    this._phone.addListener('log', function (content) {
+      context._dispatch.log(content.action, content.data);
     });
-    this._phone.post('observe', 'pressureProbeFiltered');
-    // END OF HACK
   };
 
   return IFrameModel;


### PR DESCRIPTION
Summary:

- There is a new `LogController` which is responsible for logging to parent window (it can be either LARA or CODAP).
- All the components log when user interacts with them (button is clicked, checkbox checked, etc.)
- All basic logs that are not specific to CODAP are extracted from `ExportsController` (e.g. "StartedModel", "ReloadedModel", "StoppedModel").
- Logging can be configured in the interactive JSON, please see [metadata spec](https://github.com/concord-consortium/lab/blob/19cc26efe39bfa4a674672fb4e20b6d7ef61446e/src/lab/common/controllers/interactive-metadata.js#L299-L316).
- Logging is enabled by default, even if you don't specify `logging` section in JSON. Then all the default values from metadata will be used, so we will log interaction with all the components and we will log all the properties that are bound to components (on model start, stop and reload).

This pull request introduces kind of breaking change - we used to log some parameters on model start and reload. These parameters were either specified in `exports.perRun` section in the interactive JSON or all the **writable** properties bound to components were used by default (if `exports` was undefined).

Now, the default strategy is a bit different - we will simply log **all** properties bound to the components. Writable and read-only (=> outputs in most cases). I think it makes sense, as it's simpler. Also, it shouldn't cause any problems, as we will log the same properties + a few more in some (rare) cases.

In case interactive JSON lists properties that should be logged explicitly in `exports.perRun`, we need to make sure that new default behaviour coverts that or specify these properties manually in `logging.parameters` list. I'll check all the interactives with `exports` section defined in lab-interactives-site (there are not so many).