### PR TITLE
Simplify logging format

### DIFF
--- a/src/lab/import-export/dg-exporter.js
+++ b/src/lab/import-export/dg-exporter.js
@@ -87,8 +87,12 @@ define(function(require) {
       return false;
     },
 
-    canExportData: function() {
+    isEmbeddedInCODAP: function() {
       return this.isCodapPresent || this.canCallDGDirect();
+    },
+
+    canExportData: function() {
+      return this.isEmbeddedInCODAP();
     },
 
     doCommand: function(name, args, callback) {


### PR DESCRIPTION
1. Don't use RPC anymore (logging doesn't seem like a remote procedure call). 
2. Don't expect "lara-logging-present" message - parent can ignore log messages if it's not interested. 
3. Use simpler format, the same which is used by iframe-models that log to Lab:
`post("log", {action: "someAction", data: {val1: 1, val2: 2})`.

It simplifies things a lot, no setup and expectations, parent doesn't even need to use iframePhone to listen to our logs.

