### PR TITLE
Don't display fullscreen button if fullscreen is not available

### DIFF
--- a/license.md
+++ b/license.md
@@ -59,6 +59,7 @@ Here is a list of projects and resources included in the in the `vendor/` direct
 22. [i18next](https://github.com/jamuhl/i18next): [MIT](http://www.opensource.org/licenses/MIT)
 23. [lab-grapher](https://github.com/concord-consortium/lab-grapher): triple-licensed the same as the Lab licenses
 24. [lab-sensor-applet-interface-dist](https://github.com/concord-consortium/lab-sensor-applet-interface-dist): triple-licensed the same as Lab, with exceptions for some binary libraries provided by Vernier
+25. [screenfull](https://github.com/sindresorhus/screenfull.js): [MIT](http://www.opensource.org/licenses/MIT)
 
 In addition there are two fontface directories in `vendor/fonts` that are distributed
 under compatible open source licenses:

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "backbone": "1.1.0",
     "underscore": ">=1.5.1",
     "uglify-js": ">=2.4.0",
-    "markdown": ">=0.5.0"
+    "markdown": ">=0.5.0",
+    "screenfull": "^3.0.0"
   },
   "devDependencies": {
     "jsdom": ">=0.8.9 < 1.0",

--- a/src/lab/common/controllers/setup-banner.js
+++ b/src/lab/common/controllers/setup-banner.js
@@ -7,6 +7,7 @@ define(function () {
       ImageController    = require('common/controllers/image-controller'),
       DivController      = require('common/controllers/div-controller'),
       PlaybackController = require('common/controllers/playback-controller'),
+      screenfull         = require('screenfull'),
 
       topBarHeight    = 1.5,
       topBarFontScale = topBarHeight * 0.65,
@@ -236,37 +237,8 @@ define(function () {
         "belowOthers": true
       });
 
-      // see if we can go fullscreen. If we can, add a fullscreen button.
-      // Note: This requires iframe to be embedded with 'allowfullscreen=true' (and
-      // browser-specific variants). If iframe is not embedded with this property, button
-      // will show but will not work. It is not clear whether we can find out at this moment
-      // whether iframe was embedded appropriately.
-      body = document.body;
-
-      requestFullscreenMethod =
-        body.requestFullScreen ||
-        body.webkitRequestFullScreen ||
-        body.mozRequestFullScreen ||
-        body.msRequestFullScreen;
-
-      document.cancelFullscreenMethod =
-        document.cancelFullScreen ||
-        document.webkitCancelFullScreen ||
-        document.mozCancelFullScreen ||
-        document.msCancelFullScreen;
-
-      function isFullscreen() {
-        // this doesn't yet exist in Safari
-        if (document.fullscreenElement ||
-          document.webkitFullscreenElement ||
-          document.mozFullScreenElement) {
-          return true;
-        }
-        // annoying hack to check Safari
-        return ~$(".fullscreen").css("background-image").indexOf("exit");
-      }
-
-      if (requestFullscreenMethod) {
+      if (screenfull.enabled) {
+        // Note: This requires iframe to be embedded with 'allowfullscreen=true'.
         createElementInContainer({
           "type": "div",
           "id": "fullsize-link",
@@ -275,11 +247,11 @@ define(function () {
           "classes": ["fullscreen"],
           "tooltip": i18n.t("banner.fullscreen_tooltip"),
           "onClick": function () {
-            if (!isFullscreen()) {
-              requestFullscreenMethod.call(body);
+            if (!screenfull.isFullscreen) {
+              screenfull.request(document.body);
               controller.logAction('FullScreenStarted');
             } else {
-              document.cancelFullscreenMethod();
+              screenfull.exit();
             }
           }
         },

--- a/src/lab/lab.build.js
+++ b/src/lab/lab.build.js
@@ -62,6 +62,9 @@
         'rgbcolor'
       ],
       exports: 'canvg'
+    },
+    'screenfull': {
+      exports: 'screenfull'
     }
   },
 
@@ -82,6 +85,7 @@
     'backbone': '../../node_modules/backbone/backbone',
     'mustache': '../../node_modules/mustache/mustache',
     'markdown': '../../node_modules/markdown/lib/markdown',
+    'screenfull': '../../node_modules/screenfull/dist/screenfull',
     'sensor-applet': '../../vendor/lab-sensor-applet-interface-dist/sensor-applet-interface',
     'sensor-connector-interface': '../../vendor/sensor-connector-interface/dist/sensor-connector-interface',
     'lodash': 'empty:',


### PR DESCRIPTION
If iframe doesn't specify allowfullscreen=true, we won't display fullscreen button (as it won't work anyway).