### PR TITLE
Fix console error on atom click

### DIFF
--- a/src/lab/models/md2d/views/aminoacid-context-menu.coffee
+++ b/src/lab/models/md2d/views/aminoacid-context-menu.coffee
@@ -129,11 +129,12 @@ define (require) ->
       events:
         # Mark currently selected AA type.
         show: (options) ->
-          props = getClickedAtom()
-          if !props
+          atom = getClickedAtom()
+          aminoAcidProps = atom && aminoacids.getAminoAcidByElement(atom.element)
+          if !atom || !aminoAcidProps
             return false
 
-          key = aminoacids.getAminoAcidByElement(props.element).abbreviation
+          key = aminoAcidProps.abbreviation
           $node = options.items[key].$node
           $node.addClass MARKED_CLASS
           if $node.hasClass HYDROPHOBIC_CLASS


### PR DESCRIPTION
Open: http://lab.concord.org/interactives.html#interactives/samples/1-oil-and-water-shake.json
and click any atom (but don't drag it). You should notice an error in the console:
```Uncaught TypeError: Cannot read property 'abbreviation' of undefined```
This PR fixes that.