### PR TITLE
Molecule rotation

### DIFF
--- a/src/lab/locales/translations.json
+++ b/src/lab/locales/translations.json
@@ -57,6 +57,7 @@
       "md2d": {
         "heatbath_icon_tooltip": "Heatbath active",
         "ke_icon_tooltip": "Kinetic energy gradient",
+        "invalid_object_position_alert": "You can't drop the object there.",
         "aminoacid_menu": {
           "hydrophobic": "Hydrophobic",
           "hydrophilic": "Hydrophilic",
@@ -283,6 +284,7 @@
       "md2d": {
         "heatbath_icon_tooltip": "Stała temperatura",
         "ke_icon_tooltip": "Skala energii kinetycznej",
+        "invalid_object_position_alert": "Niepoprawna pozycja obiektu.",
         "aminoacid_menu": {
           "hydrophobic": "Hydrofobowe",
           "hydrophilic": "Hydrofilowe",
@@ -502,6 +504,7 @@
       "md2d": {
         "heatbath_icon_tooltip": "Varmebad er på",
         "ke_icon_tooltip": "Kinetisk energigradient",
+        "invalid_object_position_alert": "You can't drop the object there.",
         "aminoacid_menu": {
           "hydrophobic": "Hydrofob",
           "hydrophilic": "Hydrofil",
@@ -721,6 +724,7 @@
       "md2d": {
         "heatbath_icon_tooltip": "Varmebad er på",
         "ke_icon_tooltip": "Kinetisk energigradient",
+        "invalid_object_position_alert": "You can't drop the object there.",
         "aminoacid_menu": {
           "hydrophobic": "Hydrofob",
           "hydrophilic": "Hydrofil",
@@ -944,6 +948,7 @@
       "md2d": {
         "heatbath_icon_tooltip": "Banho de calor ativo",
         "ke_icon_tooltip": "Gradiente de energia cinética",
+        "invalid_object_position_alert": "You can't drop the object there.",
         "aminoacid_menu": {
           "hydrophobic": "Hidrofóbico",
           "hydrophilic": "Hidrofílico",
@@ -1173,6 +1178,7 @@
       "md2d": {
         "heatbath_icon_tooltip": "Vodní lázeň",
         "ke_icon_tooltip": "Gradient kinetické energie",
+        "invalid_object_position_alert": "You can't drop the object there.",
         "aminoacid_menu": {
           "hydrophobic": "Hydrofobní",
           "hydrophilic": "Hydrofilní",

--- a/src/lab/models/md2d/models/metadata.js
+++ b/src/lab/models/md2d/models/metadata.js
@@ -317,6 +317,12 @@ define(function() {
       },
       forceVectorsDirectionOnly: {
         defaultValue: false
+      },
+      onAtomDrag: {
+        // Atom dragging can either start translation or rotation of the molecule.
+        // Behavior which is not default can be activated if user holds Alt / Opt key while dragging.
+        // Available options: 'translate', 'rotate'.
+        defaultValue: 'translate'
       }
     },
 

--- a/test/fixtures/mml-conversions/expected-json/angular-bonds.json
+++ b/test/fixtures/mml-conversions/expected-json/angular-bonds.json
@@ -73,7 +73,9 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate",
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/custom-element-colors.json
+++ b/test/fixtures/mml-conversions/expected-json/custom-element-colors.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/custom-lj-properties.json
+++ b/test/fixtures/mml-conversions/expected-json/custom-lj-properties.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [
     {

--- a/test/fixtures/mml-conversions/expected-json/draggable-atom.json
+++ b/test/fixtures/mml-conversions/expected-json/draggable-atom.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/electric-field.json
+++ b/test/fixtures/mml-conversions/expected-json/electric-field.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/ellipse-alhpa-at-props.json
+++ b/test/fixtures/mml-conversions/expected-json/ellipse-alhpa-at-props.json
@@ -181,7 +181,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [
     {

--- a/test/fixtures/mml-conversions/expected-json/gravitational-field-100.json
+++ b/test/fixtures/mml-conversions/expected-json/gravitational-field-100.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/gravitational-field-200-default.json
+++ b/test/fixtures/mml-conversions/expected-json/gravitational-field-200-default.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/gravitational-field-400.json
+++ b/test/fixtures/mml-conversions/expected-json/gravitational-field-400.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/gravitational-field-off.json
+++ b/test/fixtures/mml-conversions/expected-json/gravitational-field-off.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/heatbath.json
+++ b/test/fixtures/mml-conversions/expected-json/heatbath.json
@@ -74,7 +74,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/image-layers.json
+++ b/test/fixtures/mml-conversions/expected-json/image-layers.json
@@ -114,7 +114,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/image-visible-and-hidden.json
+++ b/test/fixtures/mml-conversions/expected-json/image-visible-and-hidden.json
@@ -93,7 +93,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/immovable-atom.json
+++ b/test/fixtures/mml-conversions/expected-json/immovable-atom.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/invisible-obstacle.json
+++ b/test/fixtures/mml-conversions/expected-json/invisible-obstacle.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/mark-atoms.json
+++ b/test/fixtures/mml-conversions/expected-json/mark-atoms.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/mazeGame.json
+++ b/test/fixtures/mml-conversions/expected-json/mazeGame.json
@@ -96,7 +96,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/no-atoms.json
+++ b/test/fixtures/mml-conversions/expected-json/no-atoms.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/no-electric-field.json
+++ b/test/fixtures/mml-conversions/expected-json/no-electric-field.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/obstacle-color.json
+++ b/test/fixtures/mml-conversions/expected-json/obstacle-color.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/obstacle-mass.json
+++ b/test/fixtures/mml-conversions/expected-json/obstacle-mass.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/obstacle-probes.json
+++ b/test/fixtures/mml-conversions/expected-json/obstacle-probes.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/one-textbox.json
+++ b/test/fixtures/mml-conversions/expected-json/one-textbox.json
@@ -90,7 +90,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [
     {

--- a/test/fixtures/mml-conversions/expected-json/point-restraint.json
+++ b/test/fixtures/mml-conversions/expected-json/point-restraint.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/quantum-collision.json
+++ b/test/fixtures/mml-conversions/expected-json/quantum-collision.json
@@ -84,7 +84,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/rectangles.json
+++ b/test/fixtures/mml-conversions/expected-json/rectangles.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/show-charge-symbols.json
+++ b/test/fixtures/mml-conversions/expected-json/show-charge-symbols.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/show-vdw-lines.json
+++ b/test/fixtures/mml-conversions/expected-json/show-vdw-lines.json
@@ -84,7 +84,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/simple-ke-shading.json
+++ b/test/fixtures/mml-conversions/expected-json/simple-ke-shading.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/solvent-dielectric-constant.json
+++ b/test/fixtures/mml-conversions/expected-json/solvent-dielectric-constant.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/sunOnGround.json
+++ b/test/fixtures/mml-conversions/expected-json/sunOnGround.json
@@ -83,7 +83,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/target-game-distance.json
+++ b/test/fixtures/mml-conversions/expected-json/target-game-distance.json
@@ -117,7 +117,8 @@
       "width": 0.03,
       "length": 1.89
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/time-step-5.0.json
+++ b/test/fixtures/mml-conversions/expected-json/time-step-5.0.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading-image.json
+++ b/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading-image.json
@@ -94,7 +94,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [
     {

--- a/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading.json
+++ b/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/two-charged-atoms.json
+++ b/test/fixtures/mml-conversions/expected-json/two-charged-atoms.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/two-diatomic-molecules.json
+++ b/test/fixtures/mml-conversions/expected-json/two-diatomic-molecules.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/two-obstacles.json
+++ b/test/fixtures/mml-conversions/expected-json/two-obstacles.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/vectors.json
+++ b/test/fixtures/mml-conversions/expected-json/vectors.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/view-refresh-interval-10.json
+++ b/test/fixtures/mml-conversions/expected-json/view-refresh-interval-10.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/viscosity-friction.json
+++ b/test/fixtures/mml-conversions/expected-json/viscosity-friction.json
@@ -74,7 +74,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {

--- a/test/fixtures/mml-conversions/expected-json/visible-and-invisible.json
+++ b/test/fixtures/mml-conversions/expected-json/visible-and-invisible.json
@@ -73,7 +73,8 @@
       "width": 0.01,
       "length": 2
     },
-    "forceVectorsDirectionOnly": false
+    "forceVectorsDirectionOnly": false,
+    "onAtomDrag": "translate"
   },
   "pairwiseLJProperties": [],
   "elements": {


### PR DESCRIPTION
This PR adds a possibility to rotate a molecule.
To do it, you need to press Alt / Opt key and drag one atom of the molecule.

There's also a new MD2D option called `onAtomDrag`. It's default value is `translate`, but author can set it to `rotate` and then the default drag behavior would be rotation. The non-default behavior can be always accessed using Alt / Opt key.