### PR TITLE
Fix checkbox hover state

### DIFF
--- a/src/sass/lab/_interactive-components.sass
+++ b/src/sass/lab/_interactive-components.sass
@@ -195,10 +195,6 @@
     border: 1px solid #D6D7D8
     &.right
       margin: 0 0 0 0.4em
-    &.checked:after
-      -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)"
-      filter: alpha(opacity=100)
-      opacity: 1
     &:after
       -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)"
       filter: alpha(opacity=0)
@@ -220,9 +216,17 @@
       -ms-transform: rotate(-45deg)
       transform: rotate(-45deg)
     &:hover:after
-      -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=30)"
-      filter: alpha(opacity=30)
-      opacity: 0.3
+      -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=20)"
+      filter: alpha(opacity=20)
+      opacity: 0.20
+    &.checked:after
+      -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)"
+      filter: alpha(opacity=100)
+      opacity: 1
+    &:hover.checked:after
+      -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=85)"
+      filter: alpha(opacity=75)
+      opacity: 0.75
 
 .interactive-table
   div.title


### PR DESCRIPTION
A small styles update that fixes this issue:

> If a checkbox is checked, hovering over the checkbox turns it a light-grey. This is the same state as hovering over the checkbox when it is not checked. So one can hover over the checkbox, click to check/uncheck and there is no visible change in the checkbox. Once you leave the checkbox you can see what state the box is in.