### PR TITLE
Respect image (offset) rotation when it's attached to the radial bond, convert rotation from MML

### DIFF
--- a/src/lab/mml-converter/mml-converter.coffee
+++ b/src/lab/mml-converter/mml-converter.coffee
@@ -746,11 +746,14 @@ define (require) ->
           imageHostType = imageHostType.slice(imageHostType.lastIndexOf(".")+1)
           imageLayer = parseInt $image.find("[property=layer]>int").text()
           imageLayerPosition = parseInt $image.find("[property=layerPosition]>byte").text()
+          visible = parseBoolean($image.find("[property=visible]>boolean").text(), true)
           imageX = parseFloat $image.find("[property=x]>double").text()
           imageY = parseFloat $image.find("[property=y]>double").text()
+          rotation = parseFloat $image.find("[property=offsetAngle]>float").text()
           [imageX, imageY] = toNextgenCoordinates imageX, imageY
-          imageVisible = parseBoolean($image.find("[property=visible]>boolean").text(), true)
-          images.push {imageUri: imageUri, imageHostIndex: imageHostIndex, imageHostType: imageHostType, imageLayer: imageLayer, imageLayerPosition: imageLayerPosition, imageX: imageX, imageY: imageY, visible: imageVisible }
+          # Convert angle to Next Gen format. We use an opposite sign and degrees instead of radians.
+          rotation = -1 * rotation * 180 / Math.PI
+          images.push {imageUri, imageHostIndex, imageHostType, imageLayer, imageLayerPosition, imageX, imageY, rotation, visible}
 
       ###
         Text boxes. TODO: factor out pattern common to MML parsing of images and text boxes

--- a/src/lab/models/md2d/views/images-renderer.js
+++ b/src/lab/models/md2d/views/images-renderer.js
@@ -139,10 +139,11 @@ define(function() {
           var imageDescription = datum.imageDescription;
           var hostType = imageDescription.imageHostType;
           var index    = imageDescription.imageHostIndex;
+          var rotation = imageDescription.rotation || 0;
           var atoms;
           var obstacles;
           var radialBond;
-          var x, y, rotation;
+          var x, y;
 
           if (hostType === 'Atom') {
             atoms = model.getAtoms();
@@ -156,15 +157,13 @@ define(function() {
             radialBond = model.getRadialBonds()[index];
             x = (radialBond.x1 + radialBond.x2) / 2;
             y = (radialBond.y1 + radialBond.y2) / 2;
-            rotation = 180 * Math.atan2(radialBond.y1 - radialBond.y2, radialBond.x1 - radialBond.x2) / Math.PI;
+            rotation += 180 * Math.atan2(radialBond.y1 - radialBond.y2, radialBond.x1 - radialBond.x2) / Math.PI;
           }
           if (x !== undefined) {
             datum.x = modelView.model2px(x);
             datum.y = modelView.model2pxInv(y);
           }
-          if (rotation !== undefined){
-            datum.rotation = rotation;
-          }
+          datum.rotation = rotation;
         });
       });
     }

--- a/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading-image.json
+++ b/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading-image.json
@@ -58,6 +58,7 @@
         "imageLayer": 1,
         "imageX": 0.8415186000032427,
         "imageY": 0.9134199679757344,
+        "rotation": -90,
         "visible": true
       }
     ],

--- a/test/fixtures/mml-conversions/input-mml/two-charged-atoms-with-shading-image.mml
+++ b/test/fixtures/mml-conversions/input-mml/two-charged-atoms-with-shading-image.mml
@@ -411,7 +411,10 @@
       </void> 
       <void property="y"> 
        <double>108.65800320242656</double> 
-      </void> 
+      </void>
+      <void property="offsetAngle">
+       <float>1.5707963267948966</float>
+      </void>
      </object> 
     </void> 
    </array> 


### PR DESCRIPTION
A small PR that fixes two issues:
- image didn't respect rotation offset value if it was attached to the radial bond
- rotation value wasn't converted from MML files