### PR TITLE
Amino acid labels

### DIFF
--- a/src/interactives/amino-acids.json
+++ b/src/interactives/amino-acids.json
@@ -31,6 +31,12 @@
     {
       "type": "checkbox",
       "id": "show-labels",
+      "text": "Show amino acid labels",
+      "property": "aminoAcidLabels"
+    },
+    {
+      "type": "checkbox",
+      "id": "three-letter-codes",
       "text": "Use three-letter codes",
       "property": "useThreeLetterCode"
     },
@@ -169,6 +175,7 @@
     "bottom": [
       [
         "show-labels",
+        "three-letter-codes",
         "select-color-scheme",
         "select-solvent"
       ],

--- a/src/lab/models/md2d/models/metadata.js
+++ b/src/lab/models/md2d/models/metadata.js
@@ -211,11 +211,15 @@ define(function() {
         defaultValue: false,
         storeInTickHistory: true
       },
-      useThreeLetterCode: {
-        defaultValue: true
-      },
       aminoAcidColorScheme: {
         defaultValue: "hydrophobicity"
+      },
+      aminoAcidLabels: {
+        defaultValue: true,
+      },
+      useThreeLetterCode: {
+        // Amino acid labels type - single letter (false) or three letters (true).
+        defaultValue: true
       },
       showChargeSymbols: {
         defaultValue: true

--- a/src/lab/models/md2d/views/atoms-renderer.js
+++ b/src/lab/models/md2d/views/atoms-renderer.js
@@ -89,8 +89,8 @@ define(function(require) {
         return h > 0 ?  ["#F0E6D1", "#E0A21B", "#AD7F1C"] : ["#dfffef", "#75a643", "#2a7216"];
       },
 
-      RENDERING_OPTIONS = ["keShading", "chargeShading", "atomNumbers", "showChargeSymbols",
-                           "aminoAcidColorScheme", "useThreeLetterCode", "viewPortZoom", "atomRadiusScale"];
+      RENDERING_OPTIONS = ["keShading", "chargeShading", "atomNumbers", "showChargeSymbols", "atomRadiusScale",
+                           "aminoAcidColorScheme", "aminoAcidLabels", "useThreeLetterCode", "viewPortZoom"];
 
   return function AtomsRenderer(modelView, model, pixiContainer, canvas) {
     // Public API object to be returned.
@@ -244,10 +244,10 @@ define(function(require) {
       if (renderMode.atomNumbers) {
         textVal = i;
         sizeRatio = 1.2;
-      } else if (renderMode.useThreeLetterCode && modelAtoms[i].label) {
+      } else if (renderMode.aminoAcidLabels && renderMode.useThreeLetterCode && modelAtoms[i].label) {
         textVal = modelAtoms[i].label;
         sizeRatio = 1;
-      } else if (!renderMode.useThreeLetterCode && modelAtoms[i].symbol) {
+      } else if (renderMode.aminoAcidLabels && !renderMode.useThreeLetterCode && modelAtoms[i].symbol) {
         textVal = modelAtoms[i].symbol;
         sizeRatio = 1.4;
       } else if (renderMode.showChargeSymbols) {

--- a/test/fixtures/mml-conversions/expected-json/angular-bonds.json
+++ b/test/fixtures/mml-conversions/expected-json/angular-bonds.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/custom-element-colors.json
+++ b/test/fixtures/mml-conversions/expected-json/custom-element-colors.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/custom-lj-properties.json
+++ b/test/fixtures/mml-conversions/expected-json/custom-lj-properties.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/draggable-atom.json
+++ b/test/fixtures/mml-conversions/expected-json/draggable-atom.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/electric-field.json
+++ b/test/fixtures/mml-conversions/expected-json/electric-field.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/ellipse-alhpa-at-props.json
+++ b/test/fixtures/mml-conversions/expected-json/ellipse-alhpa-at-props.json
@@ -40,6 +40,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/gravitational-field-100.json
+++ b/test/fixtures/mml-conversions/expected-json/gravitational-field-100.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/gravitational-field-200-default.json
+++ b/test/fixtures/mml-conversions/expected-json/gravitational-field-200-default.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/gravitational-field-400.json
+++ b/test/fixtures/mml-conversions/expected-json/gravitational-field-400.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/gravitational-field-off.json
+++ b/test/fixtures/mml-conversions/expected-json/gravitational-field-off.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/heatbath.json
+++ b/test/fixtures/mml-conversions/expected-json/heatbath.json
@@ -40,6 +40,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/image-layers.json
+++ b/test/fixtures/mml-conversions/expected-json/image-layers.json
@@ -40,6 +40,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/image-visible-and-hidden.json
+++ b/test/fixtures/mml-conversions/expected-json/image-visible-and-hidden.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/immovable-atom.json
+++ b/test/fixtures/mml-conversions/expected-json/immovable-atom.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/invisible-obstacle.json
+++ b/test/fixtures/mml-conversions/expected-json/invisible-obstacle.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/mark-atoms.json
+++ b/test/fixtures/mml-conversions/expected-json/mark-atoms.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/mazeGame.json
+++ b/test/fixtures/mml-conversions/expected-json/mazeGame.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/no-atoms.json
+++ b/test/fixtures/mml-conversions/expected-json/no-atoms.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/no-electric-field.json
+++ b/test/fixtures/mml-conversions/expected-json/no-electric-field.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/obstacle-color.json
+++ b/test/fixtures/mml-conversions/expected-json/obstacle-color.json
@@ -39,6 +39,8 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/obstacle-mass.json
+++ b/test/fixtures/mml-conversions/expected-json/obstacle-mass.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/obstacle-probes.json
+++ b/test/fixtures/mml-conversions/expected-json/obstacle-probes.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/one-textbox.json
+++ b/test/fixtures/mml-conversions/expected-json/one-textbox.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/point-restraint.json
+++ b/test/fixtures/mml-conversions/expected-json/point-restraint.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/quantum-collision.json
+++ b/test/fixtures/mml-conversions/expected-json/quantum-collision.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/rectangles.json
+++ b/test/fixtures/mml-conversions/expected-json/rectangles.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/show-charge-symbols.json
+++ b/test/fixtures/mml-conversions/expected-json/show-charge-symbols.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": false,

--- a/test/fixtures/mml-conversions/expected-json/show-vdw-lines.json
+++ b/test/fixtures/mml-conversions/expected-json/show-vdw-lines.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/simple-ke-shading.json
+++ b/test/fixtures/mml-conversions/expected-json/simple-ke-shading.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/solvent-dielectric-constant.json
+++ b/test/fixtures/mml-conversions/expected-json/solvent-dielectric-constant.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/sunOnGround.json
+++ b/test/fixtures/mml-conversions/expected-json/sunOnGround.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": false,

--- a/test/fixtures/mml-conversions/expected-json/target-game-distance.json
+++ b/test/fixtures/mml-conversions/expected-json/target-game-distance.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/time-step-5.0.json
+++ b/test/fixtures/mml-conversions/expected-json/time-step-5.0.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading-image.json
+++ b/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading-image.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading.json
+++ b/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/two-charged-atoms.json
+++ b/test/fixtures/mml-conversions/expected-json/two-charged-atoms.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/two-diatomic-molecules.json
+++ b/test/fixtures/mml-conversions/expected-json/two-diatomic-molecules.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/two-obstacles.json
+++ b/test/fixtures/mml-conversions/expected-json/two-obstacles.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/vectors.json
+++ b/test/fixtures/mml-conversions/expected-json/vectors.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/view-refresh-interval-10.json
+++ b/test/fixtures/mml-conversions/expected-json/view-refresh-interval-10.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/viscosity-friction.json
+++ b/test/fixtures/mml-conversions/expected-json/viscosity-friction.json
@@ -40,6 +40,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,

--- a/test/fixtures/mml-conversions/expected-json/visible-and-invisible.json
+++ b/test/fixtures/mml-conversions/expected-json/visible-and-invisible.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
     "showChargeSymbols": true,


### PR DESCRIPTION
A new property that lets authors turn off amino acid labels completely.
Demo: http://lab-framework.concord.org/branch/amino-acid-labels/embeddable.html#interactives/amino-acids.json