### PR TITLE
Add "scale" property to MD2D images

### DIFF
--- a/src/lab/mml-converter/mml-converter.coffee
+++ b/src/lab/mml-converter/mml-converter.coffee
@@ -753,7 +753,9 @@ define (require) ->
           [imageX, imageY] = toNextgenCoordinates imageX, imageY
           # Convert angle to Next Gen format. We use an opposite sign and degrees instead of radians.
           rotation = -1 * rotation * 180 / Math.PI
-          images.push {imageUri, imageHostIndex, imageHostType, imageLayer, imageLayerPosition, imageX, imageY, rotation, visible}
+          # Scale is a NextGen-only property, ClassicMW always uses 1 pixel == 0.1 Angstrom (0.01 nm) conversion.
+          scale = 1
+          images.push {imageUri, imageHostIndex, imageHostType, imageLayer, imageLayerPosition, imageX, imageY, rotation, scale, visible}
 
       ###
         Text boxes. TODO: factor out pattern common to MML parsing of images and text boxes

--- a/src/lab/models/md2d/models/metadata.js
+++ b/src/lab/models/md2d/models/metadata.js
@@ -884,6 +884,9 @@ define(function() {
       rotation: {
         defaultValue: 0
       },
+      scale: {
+        defaultValue: 1,
+      },
       opacity: {
         defaultValue: 1
       }

--- a/src/lab/models/md2d/views/images-renderer.js
+++ b/src/lab/models/md2d/views/images-renderer.js
@@ -18,7 +18,7 @@ define(function() {
     // It will create an Image object with that src, if we do not already have one, and when the
     // Image finishes loading it will update the width and height of any images in the image
     // container which have the same src.
-    function loadImage(src) {
+    function loadImage(src, scale) {
       if (imgDimBySrc[src]) {
         return;
       }
@@ -37,8 +37,8 @@ define(function() {
         // See: https://www.pivotaltracker.com/story/show/66376534
         var $image = $(image).appendTo("body");
         var imageDim = imgDimBySrc[src];
-        imageDim.width = $image.width();
-        imageDim.height = $image.height();
+        imageDim.width = $image.width() * scale;
+        imageDim.height = $image.height() * scale;
         $image.remove();
         // Resize and recenter any instances of this image currently in the DOM.
         d3.select(modelView.node)
@@ -100,7 +100,7 @@ define(function() {
           y = modelView.model2pxInv(desc.imageY);
         }
 
-        loadImage(src);
+        loadImage(src, desc.scale);
 
         layer.push({
           imageDescription: desc,
@@ -112,6 +112,7 @@ define(function() {
           x:                x,
           y:                y,
           rotation:         desc.rotation,
+          scale:            desc.scale,
           opacity:          desc.opacity,
           referencePoint:   referencePoint,
           capturesPointer:  capturesPointer,

--- a/src/models/chemical-reaction/chemical-reaction.json
+++ b/src/models/chemical-reaction/chemical-reaction.json
@@ -54,6 +54,7 @@
         "imageLayer": 1,
         "imageX": 0.3,
         "imageY": 2.42,
+        "scale": 1,
         "visible": true
       }
     ],

--- a/src/models/sun-on-ground/sunOnCO2.json
+++ b/src/models/sun-on-ground/sunOnCO2.json
@@ -54,6 +54,7 @@
         "imageLayer": 1,
         "imageX": 2.96,
         "imageY": 3.26,
+        "scale": 1,
         "visible": true
       }
     ],

--- a/src/models/sun-on-ground/sunOnGround.json
+++ b/src/models/sun-on-ground/sunOnGround.json
@@ -54,6 +54,7 @@
         "imageLayer": 1,
         "imageX": 2.96,
         "imageY": 3.26,
+        "scale": 1,
         "visible": true
       }
     ],

--- a/src/models/sun-on-ground/sunOnGroundAndCO2.json
+++ b/src/models/sun-on-ground/sunOnGroundAndCO2.json
@@ -54,6 +54,7 @@
         "imageLayer": 1,
         "imageX": 2.96,
         "imageY": 3.26,
+        "scale": 1,
         "visible": true
       }
     ],

--- a/test/fixtures/mml-conversions/expected-json/ellipse-alhpa-at-props.json
+++ b/test/fixtures/mml-conversions/expected-json/ellipse-alhpa-at-props.json
@@ -61,6 +61,7 @@
         "imageLayerPosition": 9,
         "imageX": 4.21,
         "imageY": 1.72,
+        "scale": 1,
         "visible": true
       },
       {
@@ -71,6 +72,7 @@
         "imageLayerPosition": 10,
         "imageX": 4.37,
         "imageY": 1.72,
+        "scale": 1,
         "visible": true
       },
       {
@@ -81,6 +83,7 @@
         "imageLayerPosition": 11,
         "imageX": 4.53,
         "imageY": 1.72,
+        "scale": 1,
         "visible": true
       }
     ],

--- a/test/fixtures/mml-conversions/expected-json/image-layers.json
+++ b/test/fixtures/mml-conversions/expected-json/image-layers.json
@@ -60,6 +60,7 @@
         "imageLayer": 1,
         "imageX": 0.12,
         "imageY": 2.55,
+        "scale": 1,
         "visible": true
       },
       {
@@ -70,6 +71,7 @@
         "imageLayerPosition": 1,
         "imageX": 1.73,
         "imageY": 2.76,
+        "scale": 1,
         "visible": true
       },
       {
@@ -80,6 +82,7 @@
         "imageLayerPosition": 2,
         "imageX": 0.18,
         "imageY": 1.28,
+        "scale": 1,
         "visible": true
       },
       {
@@ -90,6 +93,7 @@
         "imageLayerPosition": 3,
         "imageX": 1.88,
         "imageY": 1.42,
+        "scale": 1,
         "visible": true
       }
     ],

--- a/test/fixtures/mml-conversions/expected-json/image-visible-and-hidden.json
+++ b/test/fixtures/mml-conversions/expected-json/image-visible-and-hidden.json
@@ -59,6 +59,7 @@
         "imageLayer": 1,
         "imageX": 0.1,
         "imageY": 2.78,
+        "scale": 1,
         "visible": true
       },
       {
@@ -69,6 +70,7 @@
         "imageLayerPosition": 1,
         "imageX": 1.05,
         "imageY": 2.81,
+        "scale": 1,
         "visible": false
       }
     ],

--- a/test/fixtures/mml-conversions/expected-json/sunOnGround.json
+++ b/test/fixtures/mml-conversions/expected-json/sunOnGround.json
@@ -59,6 +59,7 @@
         "imageLayer": 1,
         "imageX": 2.96,
         "imageY": 3.26,
+        "scale": 1,
         "visible": true
       }
     ],

--- a/test/fixtures/mml-conversions/expected-json/target-game-distance.json
+++ b/test/fixtures/mml-conversions/expected-json/target-game-distance.json
@@ -60,6 +60,7 @@
         "imageLayerPosition": 7,
         "imageX": 2.25,
         "imageY": 3.64,
+        "scale": 1,
         "visible": true
       },
       {
@@ -70,6 +71,7 @@
         "imageLayerPosition": 8,
         "imageX": 4.07,
         "imageY": 3.42,
+        "scale": 1,
         "visible": true
       }
     ],

--- a/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading-image.json
+++ b/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading-image.json
@@ -60,6 +60,7 @@
         "imageX": 0.8415186000032427,
         "imageY": 0.9134199679757344,
         "rotation": -90,
+        "scale": 1,
         "visible": true
       }
     ],


### PR DESCRIPTION
A simple feature that makes authoring easier (we're not constrained by 1px = 0.01nm conversion anymore) and lets us support high-dpi displays.