### PR TITLE
Let authors specify custom credits per interactive

### DIFF
--- a/src/lab/common/controllers/credits-dialog.js
+++ b/src/lab/common/controllers/credits-dialog.js
@@ -3,10 +3,13 @@ define(function (require) {
 
   var labConfig        = require('lab.config'),
       mustache         = require('mustache'),
+      markdownToHTML   = require('common/markdown-to-html'),
       inherit          = require('common/inherit'),
       BasicDialog      = require('common/controllers/basic-dialog'),
       getCopyright     = require('common/controllers/copyright'),
-      creditsDialogTpl = require('text!common/controllers/credits-dialog.tpl');
+      creditsDialogTpl = require('text!common/controllers/credits-dialog.tpl'),
+      CONCORD_URL = 'http://concord.org',
+      NEXT_GEN_URL = 'http://mw.concord.org/nextgen/';
 
   /**
    * Credits Dialog. Inherits from Basic Dialog.
@@ -32,8 +35,8 @@ define(function (require) {
         origin         = document.location.href.match(/(.*?\/\/.*?)\//)[1],
         embeddablePath = document.location.pathname,
         i18n           = this._i18n,
-        concordUrl     = 'http://concord.org',
-        nextGenUrl     = 'http://mw.concord.org/nextgen/',
+        concordUrl     = CONCORD_URL,
+        nextGenUrl     = NEXT_GEN_URL,
         interactiveCreditsUrl,
         utmString;
 
@@ -54,7 +57,8 @@ define(function (require) {
     }
 
     var view = {
-      credits_text: i18n.t("credits_dialog.credits_text", {
+      // Content of the credits dialog. If it's not specified, the default, translatable text will be used.
+      credits_text: interactive.credits ? markdownToHTML(interactive.credits) : i18n.t("credits_dialog.credits_text", {
         CC_link: "<a class='opens-in-new-window' href='" + concordUrl + "' target='_blank'>Concord Consortium</a>",
         Next_Gen_MW_link: "<a class='opens-in-new-window' href='" + nextGenUrl + " ' target='_blank'>Next-Generation Molecular Workbench</a>",
         Google_link: "<a class='opens-in-new-window' href='http://www.google.org/' target='_blank'>Google.org</a>"

--- a/src/lab/common/controllers/interactive-metadata.js
+++ b/src/lab/common/controllers/interactive-metadata.js
@@ -52,6 +52,11 @@ define(function() {
         defaultValue: true
       },
 
+      credits: {
+        // Content of the credits dialog. If it's not specified, the default, translatable text will be used.
+        defaultValue: ''
+      },
+
       padding: {
         // Top, bottom and left interactive padding, but NOT right...
         // This option was defined that way long time ago and now it has been exposed to authors.

--- a/src/lab/common/controllers/interactives-controller.js
+++ b/src/lab/common/controllers/interactives-controller.js
@@ -1524,6 +1524,7 @@ define(function (require) {
           fontScale: interactive.fontScale,
           lang: interactive.lang,
           i18nMetadata: interactive.i18nMetadata,
+          credits: interactive.credits,
           helpOnLoad: interactive.helpOnLoad,
           aboutOnLoad: interactive.aboutOnLoad,
           about: arrays.isArray(interactive.about) ? $.extend(true, [], interactive.about) : interactive.about,


### PR DESCRIPTION
Adds "credits" option to the interactive JSON. Markdown is supported.