### PR TITLE
Color and opacity of atoms

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "cheerio": "0.12.4",
     "mocha": "~1.17.1",
     "should": "3.0.1",
-    "sinon": ">=1.7.3",
+    "sinon": "~1.17.7",
     "chai": ">=1.7.2"
   },
   "directories": {

--- a/src/lab/common/views/color.js
+++ b/src/lab/common/views/color.js
@@ -5,18 +5,24 @@
  */
 define(function () {
 
-  function parseColor(color) {
-    // d3.rgb is handy, however it cannor parse RGBA colors. Use it regexp to
-    // parse rgba if it's necessary. Note that alpha channel will be ignored!
-    var rgba = color.match(/rgba\(([0-9]+),([0-9]+),([0-9]+),([0-9]+)\)/i);
+  function d3rgba(color) {
+    // Use regexp to parse rgba if it's necessary.
+    var rgba = color.match(/rgba\((\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+(?:\.\d+)?)\)/i);
     if (rgba !== null) {
-      return d3.rgb(rgba[1], rgba[2], rgba[3]);
+      return {rgb: d3.rgb(rgba[1], rgba[2], rgba[3]), a: Number(rgba[4])};
     } else {
-      return d3.rgb(color);
+      return {rgb: d3.rgb(color), a: 1};
     }
   }
 
   return {
+    /**
+     * d3.rgb is handy, however it cannot parse RGBA colors.
+     * @param  {string} color Web-compatible color definition (e.g. "red", "#ff0012", "#000", rgba(10,10,10,0.5).
+     * @return {object} Object containing two properties: `rgb` - d3.rgb color and `a` - alpha value.
+     */
+    d3rgba: d3rgba,
+
     /**
      * Returns color contrasting to specified background color (black or white).
      * Note that if background color specifies alpha channel (e.g. rgba(0,0,0,0.5)),
@@ -25,7 +31,7 @@ define(function () {
      * @return {string} Contrasting color - "#000" or "#fff".
      */
     contrastingColor: function (bg) {
-      bg = parseColor(bg);
+      bg = d3rgba(bg).rgb;
       // Calculate luminance in YIQ color space.
       // This ensures that color will be visible on background.
       // This simple algorithm is described here:
@@ -35,11 +41,11 @@ define(function () {
 
     /**
      * Converts color string to number.
-     * @param  {string} bg Web-compatible color definition (e.g. "red", "#ff0012", "#000").
+     * @param  {string} colorString Web-compatible color definition (e.g. "red", "#ff0012", "#000").
      * @return {number} Numeric value, e.g. 0xff000 when argument is "#f00", "#ff0000" or "red".
      */
     color2number: function (colorString) {
-      return parseInt(parseColor(colorString).toString().substr(1), 16);
+      return parseInt(d3rgba(colorString).rgb.toString().substr(1), 16);
     }
   };
 });

--- a/src/lab/models/md2d/models/engine/md2d.js
+++ b/src/lab/models/md2d/models/engine/md2d.js
@@ -703,7 +703,7 @@ define(function (require, exports) {
           elements.epsilon = arrays.create(num, 0, arrayTypes.floatType);
           elements.sigma   = arrays.create(num, 0, arrayTypes.floatType);
           elements.radius  = arrays.create(num, 0, arrayTypes.floatType);
-          elements.color   = arrays.create(num, 0, arrayTypes.int32Type);
+          elements.color   = [];
 
           assignShortcutReferences.elements();
         },

--- a/src/lab/models/md2d/models/engine/md2d.js
+++ b/src/lab/models/md2d/models/engine/md2d.js
@@ -734,7 +734,7 @@ define(function (require, exports) {
           // place (engine). In the future, think about separation of engine
           // properties and view-oriented properties like these:
           atoms.marked         = arrays.create(num, 0, arrayTypes.uint8Type);
-          atoms.visible        = arrays.create(num, 0, arrayTypes.uint8Type);
+          atoms.visible        = arrays.create(num, 0, arrayTypes.floatType);
           atoms.draggable      = arrays.create(num, 0, arrayTypes.uint8Type);
           atoms.draggableWhenStopped = arrays.create(num, 1, arrayTypes.uint8Type);
 

--- a/src/lab/models/md2d/models/metadata.js
+++ b/src/lab/models/md2d/models/metadata.js
@@ -374,6 +374,7 @@ define(function() {
         defaultValue: 0
       },
       visible: {
+        // Note that it also accepts fractional values, e.g. 0.5 (=> atom will be semi-transparent).
         defaultValue: 1
       },
       pinned: {

--- a/src/lab/models/md2d/views/atoms-renderer.js
+++ b/src/lab/models/md2d/views/atoms-renderer.js
@@ -186,19 +186,16 @@ define(function(require) {
       var atom = modelAtoms[i],
           elID = atom.element,
           props = model.getElementProperties(elID);
-      if (!atom.visible) {
-        return 0;
-      }
       if (atom.marked || atom.aminoAcid || renderMode.keShading || renderMode.chargeShading) {
-        // Special render modes, ignore atom's color and make sure it's visible.
-        return 1;
+        // Special render modes, ignore atom's color.
+        return atom.visible;
       }
       if (typeof props.color === "number") {
         // Colors specified in Classic MW format don't support alpha channel.
-        return 1;
+        return atom.visible;
       }
-      // Color defined in HTML format support alpha (e.g. rgba(...)).
-      return d3rgba(props.color).a;
+      // Color defined in HTML format can define alpha channel too (e.g. rgba(...)).
+      return d3rgba(props.color).a * atom.visible;
     }
 
     function getAtomTexture(i, colors) {

--- a/src/lab/models/md2d/views/bonds-renderer.js
+++ b/src/lab/models/md2d/views/bonds-renderer.js
@@ -60,7 +60,7 @@ define(function(require) {
           sinThetaSpikes = sintheta * numTurns,
           pointX, pointY, i;
 
-      graphics.lineStyle(getBondWidth(d), getBondColor(d, 1));
+      graphics.lineStyle(getBondWidth(d), getBondColor(d, 1), getBondOpacity(d, 1));
       graphics.moveTo(x1, y1);
       for (i = 0; i < numTurns; i++) {
         if (i % 2 === 0) {
@@ -95,6 +95,10 @@ define(function(require) {
           yMid = y1 + midRatio * dy,
 
           bondWidth = getBondWidth(d),
+          bondColor1 = getBondColor(d, 1),
+          bondColor2 = getBondColor(d, 2),
+          bondOpacity1 = getBondOpacity(d, 1),
+          bondOpacity2 = getBondOpacity(d, 2),
           bondShift, bondAngle, xs, ys;
 
       if (d.type === RADIAL_BOND_TYPES.DOUBLE_BOND) {
@@ -103,13 +107,13 @@ define(function(require) {
         xs = Math.sin(bondAngle) * bondShift;
         ys = -Math.cos(bondAngle) * bondShift;
 
-        graphics.lineStyle(bondWidth, getBondColor(d, 1));
+        graphics.lineStyle(bondWidth, bondColor1, bondOpacity1);
         graphics.moveTo(x1 + xs, y1 + ys);
         graphics.lineTo(xMid + xs, yMid + ys);
         graphics.moveTo(x1 - xs, y1 - ys);
         graphics.lineTo(xMid - xs, yMid - ys);
 
-        graphics.lineStyle(bondWidth, getBondColor(d, 2));
+        graphics.lineStyle(bondWidth, bondColor2, bondOpacity2);
         graphics.moveTo(xMid + xs, yMid + ys);
         graphics.lineTo(x2 + xs, y2 + ys);
         graphics.moveTo(xMid - xs, yMid - ys);
@@ -120,7 +124,7 @@ define(function(require) {
         xs = Math.sin(bondAngle) * bondShift;
         ys = -Math.cos(bondAngle) * bondShift;
 
-        graphics.lineStyle(bondWidth, getBondColor(d, 1));
+        graphics.lineStyle(bondWidth, bondColor1, bondOpacity1);
         graphics.moveTo(x1, y1);
         graphics.lineTo(xMid, yMid);
         graphics.moveTo(x1 + xs, y1 + ys);
@@ -128,7 +132,7 @@ define(function(require) {
         graphics.moveTo(x1 - xs, y1 - ys);
         graphics.lineTo(xMid - xs, yMid - ys);
 
-        graphics.lineStyle(bondWidth, getBondColor(d, 2));
+        graphics.lineStyle(bondWidth, bondColor2, bondOpacity2);
         graphics.moveTo(xMid, yMid);
         graphics.lineTo(x2, y2);
         graphics.moveTo(xMid + xs, yMid + ys);
@@ -138,11 +142,11 @@ define(function(require) {
       } else if (d.type !== RADIAL_BOND_TYPES.GHOST) {
         // STANDARD_STICK and other types that are not yet supported.
         // However, GHOST bonds will not be drawn.
-        graphics.lineStyle(bondWidth, getBondColor(d, 1));
+        graphics.lineStyle(bondWidth, bondColor1, bondOpacity1);
         graphics.moveTo(x1, y1);
         graphics.lineTo(xMid, yMid);
 
-        graphics.lineStyle(bondWidth, getBondColor(d, 2));
+        graphics.lineStyle(bondWidth, bondColor2, bondOpacity2);
         graphics.moveTo(xMid, yMid);
         graphics.lineTo(x2, y2);
       }
@@ -157,6 +161,14 @@ define(function(require) {
         return parseInt(atomsRenderer.getAtomColors(d.atom1)[2].substr(1), 16);
       } else if (num === 2) {
         return parseInt(atomsRenderer.getAtomColors(d.atom2)[2].substr(1), 16);
+      }
+    }
+
+    function getBondOpacity(d, num) {
+      if (num === 1) {
+        return atomsRenderer.getAtomOpacity(d.atom1);
+      } else if (num === 2) {
+        return atomsRenderer.getAtomOpacity(d.atom2);
       }
     }
 


### PR DESCRIPTION
- Atoms rendering supports alpha channel / opacity. It can be specified via color definition or "visible" property (see below).
- Atom color can be specified using typical HTML color definition, including rgba (e.g. "#ff00aa", "rgb(100,50,20)" or "rgba(10,50,20,0.5)"). Old format is still supported (magic numbers coming from Classic MW).
- Atom's "visible" property now accepts fractional values within [0, 1] range, so it can be used to control atom's opacity. The name isn't perfect, but it's backward compatible and we don't need to add another property.
- Radial bonds follow atom's opacity now. When atoms are invisible, radial bonds will be invisible too.