### PR TITLE
Charge shading style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@ Thumbs.db
 
 # editor-related files
 *.sublime-workspace
+.idea
 .project
 /*.log

--- a/src/lab/models/md2d/models/metadata.js
+++ b/src/lab/models/md2d/models/metadata.js
@@ -211,6 +211,11 @@ define(function() {
         defaultValue: false,
         storeInTickHistory: true
       },
+      chargeShadingStyle: {
+        // "biology" (+ blue, - red) or "chemistry" (+ red, - blue).
+        defaultValue: "biology",
+        storeInTickHistory: true
+      },
       aminoAcidColorScheme: {
         defaultValue: "hydrophobicity"
       },

--- a/src/lab/models/md2d/views/atoms-renderer.js
+++ b/src/lab/models/md2d/views/atoms-renderer.js
@@ -56,32 +56,32 @@ define(function(require) {
       // Scales used for Charge Shading gradients.
       CHARGE_SHADING_STEPS = 25,
       NEUTRAL_COLORS = ["#FFFFFF", "#f2f2f2", "#A4A4A4"],
-      posLightColor = d3.scale.linear()
+      chargeBlueLightColor = d3.scale.linear()
         .interpolate(d3.interpolateRgb)
         .range(["#FFFFFF", "#ffefff"]),
-      posMedColor = d3.scale.linear()
+      chargeBlueMedColor = d3.scale.linear()
         .interpolate(d3.interpolateRgb)
         .range(["#f2f2f2", "#9090FF"]),
-      posDarkColor = d3.scale.linear()
+      chargeBlueDarkColor = d3.scale.linear()
         .interpolate(d3.interpolateRgb)
         .range(["#A4A4A4", "#3030FF"]),
-      negLightColor = d3.scale.linear()
+      chargeRedLightColor = d3.scale.linear()
         .interpolate(d3.interpolateRgb)
         .range(["#FFFFFF", "#dfffff"]),
-      negMedColor = d3.scale.linear()
+      chargeRedMedColor = d3.scale.linear()
         .interpolate(d3.interpolateRgb)
         .range(["#f2f2f2", "#FF8080"]),
-      negDarkColor = d3.scale.linear()
+      chargeRedDarkColor = d3.scale.linear()
         .interpolate(d3.interpolateRgb)
         .range(["#A4A4A4", "#FF2020"]),
 
-      getChargeShadingColors = function (charge) {
+      getChargeShadingColors = function (charge, style) {
         var chargeIndex = Math.round(Math.min(Math.abs(charge) / 3, 1) * CHARGE_SHADING_STEPS);
         chargeIndex /= CHARGE_SHADING_STEPS;
-        if (charge > 0) {
-          return [posLightColor(chargeIndex), posMedColor(chargeIndex), posDarkColor(chargeIndex)];
-        } else if (charge < 0) {
-          return [negLightColor(chargeIndex), negMedColor(chargeIndex), negDarkColor(chargeIndex)];
+        if (style === 'biology' && charge > 0 || style === 'chemistry' && charge < 0) {
+          return [chargeBlueLightColor(chargeIndex), chargeBlueMedColor(chargeIndex), chargeBlueDarkColor(chargeIndex)];
+        } else if (style === 'biology' && charge < 0 || style === 'chemistry' && charge > 0) {
+          return [chargeRedLightColor(chargeIndex), chargeRedMedColor(chargeIndex), chargeRedDarkColor(chargeIndex)];
         }
         return NEUTRAL_COLORS;
       },
@@ -90,8 +90,8 @@ define(function(require) {
         return h > 0 ?  ["#F0E6D1", "#E0A21B", "#AD7F1C"] : ["#dfffef", "#75a643", "#2a7216"];
       },
 
-      RENDERING_OPTIONS = ["keShading", "chargeShading", "atomNumbers", "showChargeSymbols", "atomRadiusScale",
-                           "aminoAcidColorScheme", "aminoAcidLabels", "useThreeLetterCode", "viewPortZoom"];
+      RENDERING_OPTIONS = ["keShading", "chargeShading", "chargeShadingStyle", "atomNumbers", "showChargeSymbols",
+                           "atomRadiusScale", "aminoAcidColorScheme", "aminoAcidLabels", "useThreeLetterCode", "viewPortZoom"];
 
   return function AtomsRenderer(modelView, model, pixiContainer, canvas) {
     // Public API object to be returned.
@@ -150,12 +150,12 @@ define(function(require) {
       if (atom.aminoAcid) {
         switch(renderMode.aminoAcidColorScheme) {
           case "charge":
-            return getChargeShadingColors(atom.charge);
+            return getChargeShadingColors(atom.charge, renderMode.chargeShadingStyle);
           case "hydrophobicity":
             return getHydrophobicityColors(atom.hydrophobicity);
           case "chargeAndHydro":
             if (atom.charge !== 0) {
-              return getChargeShadingColors(atom.charge);
+              return getChargeShadingColors(atom.charge, renderMode.chargeShadingStyle);
             }
             return getHydrophobicityColors(atom.hydrophobicity);
           // case "none":
@@ -166,7 +166,7 @@ define(function(require) {
       if (renderMode.keShading) {
         return KE_SHADING_MIN_COLORS;
       } else if (renderMode.chargeShading) {
-        return getChargeShadingColors(atom.charge);
+        return getChargeShadingColors(atom.charge, renderMode.chargeShadingStyle);
       } else {
         if (typeof props.color === "number") {
           // Weird conversion, as we use color values literally imported from Classic MW. Perhaps we

--- a/src/lab/models/md2d/views/bonds-renderer.js
+++ b/src/lab/models/md2d/views/bonds-renderer.js
@@ -16,7 +16,7 @@ define(function(require) {
         DISULPHIDE_BOND: 109
       },
 
-      RENDERING_OPTIONS = ["keShading", "chargeShading", "aminoAcidColorScheme"];
+      RENDERING_OPTIONS = ["keShading", "chargeShading", "chargeShadingStyle", "aminoAcidColorScheme"];
 
   return function BondsRenderer(modelView, model, pixiContainer, atomsRenderer) {
     // Public API object to be returned.

--- a/src/lab/models/md2d/views/renderer.js
+++ b/src/lab/models/md2d/views/renderer.js
@@ -1258,7 +1258,7 @@ define(function(require) {
 
       // Redraw container each time when some visual-related property is changed.
       model.addPropertiesListener([
-          "chargeShading", "showChargeSymbols", "useThreeLetterCode",
+          "chargeShading", "chargeShadingStyle", "showChargeSymbols", "useThreeLetterCode",
           "showAtomTrace", "atomTraceId", "aminoAcidColorScheme",
           "backgroundColor", "markColor", "forceVectorsDirectionOnly"
         ],

--- a/test/fixtures/mml-conversions/expected-json/angular-bonds.json
+++ b/test/fixtures/mml-conversions/expected-json/angular-bonds.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/custom-element-colors.json
+++ b/test/fixtures/mml-conversions/expected-json/custom-element-colors.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/custom-lj-properties.json
+++ b/test/fixtures/mml-conversions/expected-json/custom-lj-properties.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/draggable-atom.json
+++ b/test/fixtures/mml-conversions/expected-json/draggable-atom.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/electric-field.json
+++ b/test/fixtures/mml-conversions/expected-json/electric-field.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/ellipse-alhpa-at-props.json
+++ b/test/fixtures/mml-conversions/expected-json/ellipse-alhpa-at-props.json
@@ -40,6 +40,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/gravitational-field-100.json
+++ b/test/fixtures/mml-conversions/expected-json/gravitational-field-100.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/gravitational-field-200-default.json
+++ b/test/fixtures/mml-conversions/expected-json/gravitational-field-200-default.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/gravitational-field-400.json
+++ b/test/fixtures/mml-conversions/expected-json/gravitational-field-400.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/gravitational-field-off.json
+++ b/test/fixtures/mml-conversions/expected-json/gravitational-field-off.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/heatbath.json
+++ b/test/fixtures/mml-conversions/expected-json/heatbath.json
@@ -40,6 +40,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/image-layers.json
+++ b/test/fixtures/mml-conversions/expected-json/image-layers.json
@@ -40,6 +40,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/image-visible-and-hidden.json
+++ b/test/fixtures/mml-conversions/expected-json/image-visible-and-hidden.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/immovable-atom.json
+++ b/test/fixtures/mml-conversions/expected-json/immovable-atom.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/invisible-obstacle.json
+++ b/test/fixtures/mml-conversions/expected-json/invisible-obstacle.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/mark-atoms.json
+++ b/test/fixtures/mml-conversions/expected-json/mark-atoms.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/mazeGame.json
+++ b/test/fixtures/mml-conversions/expected-json/mazeGame.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/no-atoms.json
+++ b/test/fixtures/mml-conversions/expected-json/no-atoms.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/no-electric-field.json
+++ b/test/fixtures/mml-conversions/expected-json/no-electric-field.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/obstacle-color.json
+++ b/test/fixtures/mml-conversions/expected-json/obstacle-color.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,

--- a/test/fixtures/mml-conversions/expected-json/obstacle-mass.json
+++ b/test/fixtures/mml-conversions/expected-json/obstacle-mass.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/obstacle-probes.json
+++ b/test/fixtures/mml-conversions/expected-json/obstacle-probes.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/one-textbox.json
+++ b/test/fixtures/mml-conversions/expected-json/one-textbox.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/point-restraint.json
+++ b/test/fixtures/mml-conversions/expected-json/point-restraint.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/quantum-collision.json
+++ b/test/fixtures/mml-conversions/expected-json/quantum-collision.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/rectangles.json
+++ b/test/fixtures/mml-conversions/expected-json/rectangles.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/show-charge-symbols.json
+++ b/test/fixtures/mml-conversions/expected-json/show-charge-symbols.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/show-vdw-lines.json
+++ b/test/fixtures/mml-conversions/expected-json/show-vdw-lines.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/simple-ke-shading.json
+++ b/test/fixtures/mml-conversions/expected-json/simple-ke-shading.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/solvent-dielectric-constant.json
+++ b/test/fixtures/mml-conversions/expected-json/solvent-dielectric-constant.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/sunOnGround.json
+++ b/test/fixtures/mml-conversions/expected-json/sunOnGround.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/target-game-distance.json
+++ b/test/fixtures/mml-conversions/expected-json/target-game-distance.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/time-step-5.0.json
+++ b/test/fixtures/mml-conversions/expected-json/time-step-5.0.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading-image.json
+++ b/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading-image.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading.json
+++ b/test/fixtures/mml-conversions/expected-json/two-charged-atoms-with-shading.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/two-charged-atoms.json
+++ b/test/fixtures/mml-conversions/expected-json/two-charged-atoms.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/two-diatomic-molecules.json
+++ b/test/fixtures/mml-conversions/expected-json/two-diatomic-molecules.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/two-obstacles.json
+++ b/test/fixtures/mml-conversions/expected-json/two-obstacles.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/vectors.json
+++ b/test/fixtures/mml-conversions/expected-json/vectors.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": true,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/view-refresh-interval-10.json
+++ b/test/fixtures/mml-conversions/expected-json/view-refresh-interval-10.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/viscosity-friction.json
+++ b/test/fixtures/mml-conversions/expected-json/viscosity-friction.json
@@ -40,6 +40,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/mml-conversions/expected-json/visible-and-invisible.json
+++ b/test/fixtures/mml-conversions/expected-json/visible-and-invisible.json
@@ -39,6 +39,7 @@
     "keShadingMinEnergy": 0,
     "keShadingMaxEnergy": 0.2,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "aminoAcidLabels": true,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",

--- a/test/fixtures/models/pressure-probes.json
+++ b/test/fixtures/models/pressure-probes.json
@@ -13,6 +13,7 @@
     "showClock": true,
     "keShading": false,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "showVDWLines": true,
     "VDWLinesCutoff": "medium",
     "showVelocityVectors": false,

--- a/test/fixtures/models/simple-model.json
+++ b/test/fixtures/models/simple-model.json
@@ -75,6 +75,7 @@
   "viewOptions": {
     "keShading": false,
     "chargeShading": false,
+    "chargeShadingStyle": "biology",
     "showVDWLines": false,
     "VDWLinesCutoff": "medium",
     "showClock": true,


### PR DESCRIPTION
This PR adds a new property: "chargeShadingStyle".
Possible values: "biology" (default), "chemistry".
It lets authors swap blue/red coloring of +/- atoms.

@ddamelin, you can take a look if naming makes sense to you (property, values).