### PR TITLE
Fix DNA Dialog and add an original DNA sequence

### DIFF
--- a/src/lab/models/md2d/controllers/scripting-api.js
+++ b/src/lab/models/md2d/controllers/scripting-api.js
@@ -636,6 +636,7 @@ define(function (require) {
         if (dnaEditDialog == null) {
           dnaEditDialog = new DNAEditDialog(parent.model);
         }
+        dnaEditDialog.bindModel(parent.model);
         dnaEditDialog.open();
       },
 

--- a/src/lab/models/md2d/views/dna-edit-dialog.js
+++ b/src/lab/models/md2d/views/dna-edit-dialog.js
@@ -57,6 +57,9 @@ define(function () {
         // Set current value of DNA code.
         $dnaTextInput.val(model.get("DNA"));
         $dialogDiv.dialog("open");
+      },
+      bindModel: function (newModel) {
+        model = newModel;
       }
     };
 

--- a/src/lab/models/md2d/views/dna-edit-dialog.js
+++ b/src/lab/models/md2d/views/dna-edit-dialog.js
@@ -6,14 +6,19 @@ define(function () {
     var api,
         $dialogDiv,
         $dnaTextInput,
+        $originalDnaInput,
         $errorMsg,
         $submitButton,
+        originalDNA = model.get("DNA"),
 
         init = function() {
           // Basic dialog elements.
           $dialogDiv = $('<div></div>');
-          $dnaTextInput = $('<input type="text" id="dna-sequence-input" size="55"></input>');
-          $dnaTextInput.appendTo($dialogDiv);
+          $originalDnaInput = $('<input type="text" size="55" disabled/>');
+          $originalDnaInput.val(originalDNA);
+          $('<div>Original sequence</div>').append($originalDnaInput).appendTo($dialogDiv);
+          $dnaTextInput = $('<input type="text" id="dna-sequence-input" size="55"/>');
+          $('<div>Edited sequence</div>').prepend($dnaTextInput).appendTo($dialogDiv);
           $errorMsg = $('<p class="error"></p>');
           $errorMsg.appendTo($dialogDiv);
 
@@ -59,7 +64,12 @@ define(function () {
         $dialogDiv.dialog("open");
       },
       bindModel: function (newModel) {
-        model = newModel;
+        if (newModel !== model) {
+          model = newModel;
+          // Model has changed, so update original DNA too.
+          originalDNA = model.get("DNA");
+          $originalDnaInput.val(originalDNA);
+        }
       }
     };
 

--- a/src/sass/lab/_dialogs.sass
+++ b/src/sass/lab/_dialogs.sass
@@ -29,6 +29,8 @@
   font-size: 0.9em
   .error
     color: #c00
+  input[disabled]
+    opacity: 0.65
 
 .copyright-section
   margin-top: 1em


### PR DESCRIPTION
DNA dialog didn't work after the model was reset. This PR adds .bindModel method (similar methods are used in other places) and adds an original DNA sequence to the DNA dialog (Frieda requested that).