### PR TITLE
Adds support of CODAP embedding to iframe and energy2d models

### DIFF
--- a/src/lab/models/energy2d/metadata.js
+++ b/src/lab/models/energy2d/metadata.js
@@ -99,6 +99,11 @@ define(function(require) {
         defaultValue: "play_reset",
         propertyChangeInvalidates: false
       },
+      controlButtonStyle: {
+        defaultValue: "video",
+        propertyChangeInvalidates: false,
+        serialize: false
+      },
       color_palette_type: {
         defaultValue: 0
       },

--- a/src/lab/models/energy2d/modeler.js
+++ b/src/lab/models/energy2d/modeler.js
@@ -561,6 +561,21 @@ define(function (require) {
           return days + ':' + f(hours) + ':' + f(minutes)  + ':' + f(seconds);
         };
       }()));
+
+      (function() {
+        var hasPlayed = false;
+        model.on('play.has-played-support', function () {
+          hasPlayed = true;
+        });
+        model.on('reset.has-played-support', function () {
+          hasPlayed = false;
+        });
+        model.defineOutput('hasPlayed', {
+          label: "has Played"
+        }, function() {
+          return hasPlayed;
+        });
+      }());
     }());
 
     return model;

--- a/src/lab/models/iframe/metadata.js
+++ b/src/lab/models/iframe/metadata.js
@@ -23,6 +23,11 @@ define(function() {
       controlButtons: {
         defaultValue: "reset",
         propertyChangeInvalidates: false
+      },
+      controlButtonStyle: {
+        defaultValue: "video",
+        propertyChangeInvalidates: false,
+        serialize: false
       }
     }
   };

--- a/src/lab/models/iframe/modeler.js
+++ b/src/lab/models/iframe/modeler.js
@@ -41,6 +41,7 @@ define(function(require) {
 
     this._phone = null;
     this._stopped = true;
+    this._hasPlayed = false;
     this._initialProperties = initialProperties;
     this._propertySupport = labModelerMixin.propertySupport;
     this._dispatch = labModelerMixin.dispatchSupport;
@@ -58,6 +59,12 @@ define(function(require) {
     // disable these buttons
     // the outer iframe in the interactives browser expects a 'reset', 'stepForward', 'stepBack' event type
     this._dispatch.addEventTypes('tick', 'tickStart', 'tickEnd', 'play', 'stop', 'reset', 'stepForward', 'stepBack', 'log');
+
+    this.defineOutput('hasPlayed', {
+      label: "has Played"
+    }, function() {
+      return this._hasPlayed;
+    }.bind(this));
   }
 
   function customSet(key, value) {
@@ -109,6 +116,7 @@ define(function(require) {
 
   IFrameModel.prototype.start = function () {
     this._phone.post({type: 'play'});
+    this._hasPlayed = true;
     return this;
   };
 


### PR DESCRIPTION
Adds support of CODAP embedding to iframe and energy2d models.

1. If `controlButtonStyle` property is not declared in metadata, it can't be observed. CODAP was notifying Lab that it was available and the property value was updated. However, the observer wasn't being called. So, users couldn't see CODAP-specific buttons. 

2. CODAP export requires the model to define `hasPlayed` output. It's been added both to iframe and energy2d models.

[#156526419]