### PR TITLE
Fix the first point of the CODAP export data

### DIFF
--- a/src/lab/common/controllers/export-controller.js
+++ b/src/lab/common/controllers/export-controller.js
@@ -175,6 +175,9 @@ define(function (require) {
         if (!initialPerRunData) {
           initialPerRunData = getCurrentPerRunData();
         }
+        // Make sure that the first point of the run shows the correct values.
+        // User might tweak the model between load / reset and starting the run.
+        perTickValues[model.stepCounter()] = getDataPoint();
       });
       model.on('invalidation.exportController', removeDataAfterStepPointer);
     }

--- a/test/mocha/common/export-controller-spec.coffee
+++ b/test/mocha/common/export-controller-spec.coffee
@@ -242,3 +242,15 @@ helpers.withIsolatedRequireJS (requirejs) ->
               "per-run output (units 1) changed?"           : false
               "per-run output (units 1) (start of run)"     : 1
               "per-run output (units 1) (sent to CODAP)"    : 1
+
+      describe "when the per-tick parameter is updated before the run starts", ->
+        beforeEach ->
+          model.properties.perTickParam = 123
+          model.start()
+          model.stop()
+
+        it "should be reflected in the timeseries data", ->
+          exportController.exportData()
+          call = codapInterface.exportData.getCall 0
+          args = call.args[3]
+          args.should.eql [[0, 2, 123]]


### PR DESCRIPTION
[#157536289]

The first point of CODAP export data used to show the value that was available on the model load and/or after reset. Now, it will show the last current value before the user clicked start.