### PR TITLE
Allow Data Hierarchy reorg when embedded in CODAP

### DIFF
--- a/src/lab/import-export/codap-interface.js
+++ b/src/lab/import-export/codap-interface.js
@@ -110,7 +110,8 @@ define(function(require) {
         var existingConfig = resp.values;
         var newIframeConfig = {
           name: this.frameConfig.title,
-          title: this.frameConfig.title
+          title: this.frameConfig.title,
+          preventDataContextReorg: false
         };
         // Update dimensions only if the interactive is added to CODAP for the first time.
         // Then, authors can adjust size of the interactive and it should not be overwritten.


### PR DESCRIPTION
Having reviewed the [PT story](https://www.pivotaltracker.com/story/show/160957951) and checked the corresponding [documentation](https://github.com/concord-consortium/codap/wiki/CODAP-Data-Interactive-Plugin-API#the-interactiveframe-object) I've added the attribute to the call to the update action. I am unsure how to test whether this works as required without additional information on the CODAP use case, but I was able to compile and embed in a local CODAP instance and export data for analysis.