### PR TITLE
Add handlers for calls to add and remove an image

### DIFF
--- a/src/lab/models/md2d/controllers/scripting-api.js
+++ b/src/lab/models/md2d/controllers/scripting-api.js
@@ -841,6 +841,14 @@ define(function (require) {
         return parent.model.getNumberOfShapes();
       },
 
+      addImage: function (props) {
+        parent.model.addImage(props);
+      },
+
+      removeImage: function (i) {
+        parent.model.removeImage(i);
+      },
+
       getImageProperties: function(i) {
         return parent.model.getImageProperties(i);
       },

--- a/src/lab/models/md2d/models/modeler.js
+++ b/src/lab/models/md2d/models/modeler.js
@@ -1504,6 +1504,22 @@ define(function(require) {
       }
     };
 
+    model.addImage = function (props) {
+      props = validator.validateCompleteness(metadata.image, props);
+      model.get('images').push(props);
+      dispatch.imagesChanged();
+    };
+
+    model.removeImage = function (i) {
+      var images = model.get('images');
+      if (i >=0 && i < images.length) {
+        model.set('images', images.slice(0,i).concat(images.slice(i+1)));
+        dispatch.imagesChanged();
+      } else {
+        throw new Error("Image \"" + i + "\" does not exist, so it cannot be removed.");
+      }
+    };
+
     model.setImageProperties = function(i, props) {
       var image = model.get('images')[i],
           prop;


### PR DESCRIPTION
Since we have the ability to add and remove textboxes on the fly, this PR implements similar functionality for images. Tested against a local lab-interactives-site instance and was able to add images to newly-added particles. Seems the event for imagesChanged already exists, so I don't think there's a lot more needed here?