### PR TITLE
Using a similar approach to the recent fix in lab-interactive-site

### DIFF
--- a/script/s3-deploy.sh
+++ b/script/s3-deploy.sh
@@ -30,4 +30,6 @@ else
   export DEPLOY_DIR
   export DEPLOY_ARCHIVE
 fi
-disable_parallel_processing=true bundle exec s3_website push --site _site --config-dir config
+disable_parallel_processing=true
+bundle exec s3_website install
+java -cp $(bundle show s3_website)/*.jar s3.website.Push --site _site --config-dir config


### PR DESCRIPTION
Travis was reporting build success, but buried in the logs it seems the s3 deployment piece was failing just as it was in the interactive site. Modifying the s3 deployment script was necessary to get the deployment to work. 