### PR TITLE
Change nucleus background color to match new styles for CBio

### DIFF
--- a/src/lab/models/md2d/views/genetic-anim-states.js
+++ b/src/lab/models/md2d/views/genetic-anim-states.js
@@ -55,7 +55,7 @@ define(function (require) {
         drag: false
       }],
       background: [{
-        color: "#8492ef"
+        color: "#55b7b2"
       }]
     });
     stateMgr.extendLastState("intro-zoom1", {
@@ -280,7 +280,7 @@ define(function (require) {
       }],
       viewPort: [{}],
       background: [{
-        color: "#8492ef"
+        color: "#55b7b2"
       }]
     });
     stateMgr.extendLastState("before-translation-s1", {


### PR DESCRIPTION
This will have a small change for anyone using the older version of this interactive, but it’s a relatively minor color change that shouldn't affect too many people. 