### PR TITLE
Adjust svg rendering of atoms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lab",
-  "version": "1.14.0",
+  "version": "1.16.5",
   "description": "HTML5-based scientific models, visualizations, graphing, and probeware",
   "keywords": [
     "molecule",

--- a/src/lab/models/md2d/views/atoms-renderer.js
+++ b/src/lab/models/md2d/views/atoms-renderer.js
@@ -31,10 +31,10 @@ define(function(require) {
         </style> \
          <defs> \
             <radialGradient id="grad" cx="50%" cy="47%" r="53%" fx="35%" fy="30%"> \
-              <stop stop-color="{{ lightCol }}" offset="0%"></stop> \
-              <stop stop-color="{{ medCol }}" offset="40%"></stop> \
-              <stop stop-color="{{ darkCol }}" offset="80%"></stop> \
-              <stop stop-color="{{ medCol }}" offset="100%"></stop> \
+              <stop style="stop-color:{{ lightCol }}" offset="0%"/> \
+              <stop style="stop-color:{{ medCol }}" offset="40%"/> \
+              <stop style="stop-color:{{ darkCol }}" offset="80%"/> \
+              <stop style="stop-color:{{ medCol }}" offset="100%"/> \
             </radialGradient> \
          </defs> \
          <g opacity="{{ opacity }}"> \
@@ -43,6 +43,7 @@ define(function(require) {
             <circle fill="url(#grad)" cx="16" cy="16" r="8"/> \
            {{/excited}} \
            {{^excited}} \
+            <circle fill="{{ medCol }}" stroke="{{ darkCol }}" cx="16" cy="16" r="14"/> \
             <circle fill="url(#grad)" cx="16" cy="16" r="16"/> \
            {{/excited}} \
            <text class="shadow" text-anchor="middle" x="16" y="16" dy="0.31em">{{ label }}</text> \

--- a/src/lab/models/md2d/views/atoms-renderer.js
+++ b/src/lab/models/md2d/views/atoms-renderer.js
@@ -40,6 +40,7 @@ define(function(require) {
          <g opacity="{{ opacity }}"> \
            {{#excited}} \
             <circle fill="#ffe600" cx="16" cy="16" r="12"/> \
+            <circle fill="{{ medCol }}" cx="16" cy="16" r="8"/> \
             <circle fill="url(#grad)" cx="16" cy="16" r="8"/> \
            {{/excited}} \
            {{^excited}} \


### PR DESCRIPTION
iOS 13 broke rendering the gradient svg particles we use in Lab. This quick fix provides a non-gradient default image for particles that will only appear if the gradient overlay fails to render, providing a fallback option for those devices having issues rendering the SVG.

The adjustments to the stop-color style did not have an effect on the SVG, the issue could be related to our use of Pixi.js, but the issue was present also in Pixi v3. Pixi is currently on v5 but this has not yet been successfully tested with Lab.