### PR TITLE
Fix sensor-connector interactive

### DIFF
--- a/src/lab/models/dual-sensor-connector/modeler.js
+++ b/src/lab/models/dual-sensor-connector/modeler.js
@@ -452,11 +452,11 @@ export default function Model(initialProperties, opt) {
       enterState: function() {
         message = i18n.t("sensor.messages.not_connected");
         statusErrors = 0;
-        if (location.protocol === 'https:') {
-          sensorConnectorInterface.startPolling(["https://localhost:11181", "https://127.0.0.1:11181", "https://localhost.ungerdesign.com:11181"], model.properties.clientId, model.properties.clientName);
-        } else {
-          sensorConnectorInterface.startPolling("http://127.0.0.1:11180", model.properties.clientId, model.properties.clientName);
-        }
+        // use https if possible, fall back to http if necessary
+        sensorConnectorInterface.startPolling([
+                                  "https://localhost:11181", "https://127.0.0.1:11181",
+                                  "http://localhost:11180", "http://127.0.0.1:11180"],
+                                  model.properties.clientId, model.properties.clientName);
         this.gotoState('connecting');
       }
     },
@@ -1054,6 +1054,11 @@ export default function Model(initialProperties, opt) {
     label: "User Message"
   }, function() {
     return message;
+  });
+
+  // set in setupModelObservers() in controller.js
+  model.defineParameter('isNewRunInProgress', {
+    initialValue: false
   });
 
   // Clean up state before we go

--- a/src/lab/models/sensor-connector/modeler.js
+++ b/src/lab/models/sensor-connector/modeler.js
@@ -329,11 +329,11 @@ export default function Model(initialProperties, opt) {
       enterState: function() {
         message = i18n.t("sensor.messages.not_connected");
         statusErrors = 0;
-        if (location.protocol === 'https:') {
-          sensorConnectorInterface.startPolling(["https://localhost:11181", "https://127.0.0.1:11181", "https://localhost.ungerdesign.com:11181"], model.properties.clientId, model.properties.clientName);
-        } else {
-          sensorConnectorInterface.startPolling("http://127.0.0.1:11180", model.properties.clientId, model.properties.clientName);
-        }
+        // use https if possible, fall back to http if necessary
+        sensorConnectorInterface.startPolling([
+                                  "https://localhost:11181", "https://127.0.0.1:11181",
+                                  "http://localhost:11180", "http://127.0.0.1:11180"],
+                                  model.properties.clientId, model.properties.clientName);
         this.gotoState('connecting');
       }
     },
@@ -891,6 +891,11 @@ export default function Model(initialProperties, opt) {
     label: "User Message"
   }, function() {
     return message;
+  });
+
+  // set in setupModelObservers() in controller.js
+  model.defineParameter('isNewRunInProgress', {
+    initialValue: false
   });
 
   // Clean up state before we go


### PR DESCRIPTION
- Always try https for sensor-connector communication and then fall back to http if necessary
- Add declaration for `isNewRunInProgress` parameter
  - without this, the Reset button encountered an error about modifying a readonly object

Note that in my testing the collection of sensor values and the reset button worked as expected for the single-sensor and the dual-sensor interactives, but the dual-sensor interactive would sometimes fail to complete the run, claiming that the sensor-connector could no longer be found. I'm inclined to think that's not related to the changes in this PR, however.