### PR TITLE
Eliminate SASS deprecation warning messages

### DIFF
--- a/src/sass/bourbon/functions/_deprecated-webkit-gradient.scss
+++ b/src/sass/bourbon/functions/_deprecated-webkit-gradient.scss
@@ -20,7 +20,7 @@
 
     @else if $gradient != null {
       @if $i == $full-length {
-        $percentage: 100%;
+        $percentage: "100%";
       }
 
       @else {


### PR DESCRIPTION
Eliminates ~20 deprecation warnings of the following form:
```
DEPRECATION WARNING: Passing 100%, a non-string value, to unquote()
will be an error in future versions of Sass.
        on line 30 of /Users/kswenson/Development/cc-dev/lab/src/sass/bourbon/functions/_deprecated-webkit-gradient.scss
```
